### PR TITLE
Use GemResolver for external gem minification tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
   external-gems:
     runs-on: ubuntu-latest
     continue-on-error: true
-    timeout-minutes: 40
+    timeout-minutes: 15
     env:
       BUNDLE_GEMFILE: Gemfile.gems_test
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,14 +41,22 @@ jobs:
           cd gem_tests
           git clone --depth 1 --branch "v${sinatra_version}" https://github.com/sinatra/sinatra
           git clone --depth 1 --branch "v${rubocop_version}" https://github.com/rubocop/rubocop
-      - name: Install sinatra test dependencies
+      - name: Prepare sinatra test environment
         working-directory: gem_tests/sinatra
         run: |
           rm -rf lib
+          cat > Gemfile.test <<GEMFILE
+          source 'https://rubygems.org'
+          gem 'sinatra'
+          gem 'rack-test'
+          gem 'rack-protection', path: 'rack-protection'
+          gem 'minitest', '~> 5.0'
+          gem 'childprocess', '>= 5'
+          GEMFILE
           bundle install --jobs 4
         env:
-          BUNDLE_GEMFILE: Gemfile
-      - name: Install rubocop test dependencies
+          BUNDLE_GEMFILE: Gemfile.test
+      - name: Prepare rubocop test environment
         working-directory: gem_tests/rubocop
         run: |
           rm -rf lib

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,23 +24,20 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     timeout-minutes: 40
+    env:
+      BUNDLE_GEMFILE: Gemfile.gems_test
     steps:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: "4.0"
-          bundler-cache: true
       - name: Clone gem sources
         run: |
           mkdir -p gem_tests
           cd gem_tests
           git clone --depth 1 https://github.com/sinatra/sinatra
           git clone --depth 1 https://github.com/rubocop/rubocop
-      - name: Install sinatra test dependencies
-        working-directory: gem_tests/sinatra
-        run: bundle install --jobs 4
-      - name: Install rubocop test dependencies
-        working-directory: gem_tests/rubocop
+      - name: Install dependencies
         run: bundle install --jobs 4
       - name: Run gem integration tests
         run: bundle exec rake test:gems

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
   external-gems:
     runs-on: ubuntu-latest
     continue-on-error: true
-    timeout-minutes: 15
+    timeout-minutes: 30
     env:
       BUNDLE_GEMFILE: Gemfile.gems_test
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,10 +35,10 @@ jobs:
         run: bundle install --jobs 4
       - name: Clone test suites matching installed gem versions
         run: |
-          mkdir -p gem_tests
-          cd gem_tests
           sinatra_version=$(bundle exec ruby -e 'puts Gem::Specification.find_by_name("sinatra").version')
           rubocop_version=$(bundle exec ruby -e 'puts Gem::Specification.find_by_name("rubocop").version')
+          mkdir -p gem_tests
+          cd gem_tests
           git clone --depth 1 --branch "v${sinatra_version}" https://github.com/sinatra/sinatra
           git clone --depth 1 --branch "v${rubocop_version}" https://github.com/rubocop/rubocop
       - name: Install sinatra test dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,22 +31,28 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: "4.0"
-      - name: Clone gem sources
+      - name: Install dependencies
+        run: bundle install --jobs 4
+      - name: Clone test suites matching installed gem versions
         run: |
           mkdir -p gem_tests
           cd gem_tests
-          git clone --depth 1 https://github.com/sinatra/sinatra
-          git clone --depth 1 https://github.com/rubocop/rubocop
-      - name: Install dependencies
-        run: bundle install --jobs 4
+          sinatra_version=$(bundle exec ruby -e 'puts Gem::Specification.find_by_name("sinatra").version')
+          rubocop_version=$(bundle exec ruby -e 'puts Gem::Specification.find_by_name("rubocop").version')
+          git clone --depth 1 --branch "v${sinatra_version}" https://github.com/sinatra/sinatra
+          git clone --depth 1 --branch "v${rubocop_version}" https://github.com/rubocop/rubocop
       - name: Install sinatra test dependencies
         working-directory: gem_tests/sinatra
-        run: bundle install --jobs 4
+        run: |
+          rm -rf lib
+          bundle install --jobs 4
         env:
           BUNDLE_GEMFILE: Gemfile
       - name: Install rubocop test dependencies
         working-directory: gem_tests/rubocop
-        run: bundle install --jobs 4
+        run: |
+          rm -rf lib
+          bundle install --jobs 4
         env:
           BUNDLE_GEMFILE: Gemfile
       - name: Run gem integration tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
         run: |
           cat > Gemfile.test <<GEMFILE
           source 'https://rubygems.org'
-          gem 'rubocop', path: '.'
+          gem 'rubocop'
           gem 'rspec', '~> 3.7'
           gem 'webmock'
           gem 'mcp', '~> 0.6'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,9 +36,25 @@ jobs:
       - name: Clone test suites matching installed gem versions
         run: |
           sinatra_version=$(bundle exec ruby -e 'puts Gem::Specification.find_by_name("sinatra").version')
+          rubocop_version=$(bundle exec ruby -e 'puts Gem::Specification.find_by_name("rubocop").version')
           mkdir -p gem_tests
           cd gem_tests
           git clone --depth 1 --branch "v${sinatra_version}" https://github.com/sinatra/sinatra
+          git clone --depth 1 --branch "v${rubocop_version}" https://github.com/rubocop/rubocop
+      - name: Prepare rubocop test environment
+        working-directory: gem_tests/rubocop
+        run: |
+          cat > Gemfile.test <<GEMFILE
+          source 'https://rubygems.org'
+          gem 'rubocop', path: '.'
+          gem 'rspec', '~> 3.7'
+          gem 'webmock'
+          gem 'mcp', '~> 0.6'
+          gem 'rake'
+          GEMFILE
+          bundle install --jobs 4
+        env:
+          BUNDLE_GEMFILE: Gemfile.test
       - name: Prepare sinatra test environment
         working-directory: gem_tests/sinatra
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,11 +36,9 @@ jobs:
       - name: Clone test suites matching installed gem versions
         run: |
           sinatra_version=$(bundle exec ruby -e 'puts Gem::Specification.find_by_name("sinatra").version')
-          rubocop_version=$(bundle exec ruby -e 'puts Gem::Specification.find_by_name("rubocop").version')
           mkdir -p gem_tests
           cd gem_tests
           git clone --depth 1 --branch "v${sinatra_version}" https://github.com/sinatra/sinatra
-          git clone --depth 1 --branch "v${rubocop_version}" https://github.com/rubocop/rubocop
       - name: Prepare sinatra test environment
         working-directory: gem_tests/sinatra
         run: |
@@ -57,10 +55,5 @@ jobs:
           bundle install --jobs 4
         env:
           BUNDLE_GEMFILE: Gemfile.test
-      - name: Prepare rubocop test environment
-        working-directory: gem_tests/rubocop
-        run: bundle install --jobs 4
-        env:
-          BUNDLE_GEMFILE: Gemfile
       - name: Run gem integration tests
         run: bundle exec rake test:gems

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,23 +44,22 @@ jobs:
       - name: Prepare sinatra test environment
         working-directory: gem_tests/sinatra
         run: |
-          rm -rf lib
           cat > Gemfile.test <<GEMFILE
           source 'https://rubygems.org'
           gem 'sinatra'
           gem 'rack-test'
           gem 'rack-protection', path: 'rack-protection'
+          gem 'rackup'
           gem 'minitest', '~> 5.0'
           gem 'childprocess', '>= 5'
+          gem 'activesupport'
           GEMFILE
           bundle install --jobs 4
         env:
           BUNDLE_GEMFILE: Gemfile.test
       - name: Prepare rubocop test environment
         working-directory: gem_tests/rubocop
-        run: |
-          rm -rf lib
-          bundle install --jobs 4
+        run: bundle install --jobs 4
         env:
           BUNDLE_GEMFILE: Gemfile
       - name: Run gem integration tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,5 +39,15 @@ jobs:
           git clone --depth 1 https://github.com/rubocop/rubocop
       - name: Install dependencies
         run: bundle install --jobs 4
+      - name: Install sinatra test dependencies
+        working-directory: gem_tests/sinatra
+        run: bundle install --jobs 4
+        env:
+          BUNDLE_GEMFILE: Gemfile
+      - name: Install rubocop test dependencies
+        working-directory: gem_tests/rubocop
+        run: bundle install --jobs 4
+        env:
+          BUNDLE_GEMFILE: Gemfile
       - name: Run gem integration tests
         run: bundle exec rake test:gems

--- a/Gemfile.gems_test
+++ b/Gemfile.gems_test
@@ -2,5 +2,4 @@
 
 eval_gemfile "Gemfile"
 
-gem "sinatra", path: "gem_tests/sinatra"
-gem "rubocop", path: "gem_tests/rubocop"
+gem "sinatra"

--- a/Gemfile.gems_test
+++ b/Gemfile.gems_test
@@ -3,3 +3,4 @@
 eval_gemfile "Gemfile"
 
 gem "sinatra"
+gem "rubocop"

--- a/Gemfile.gems_test
+++ b/Gemfile.gems_test
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+eval_gemfile "Gemfile"
+
+gem "sinatra", path: "gem_tests/sinatra"
+gem "rubocop", path: "gem_tests/rubocop"

--- a/Gemfile.gems_test.lock
+++ b/Gemfile.gems_test.lock
@@ -1,0 +1,278 @@
+GIT
+  remote: https://github.com/ruby/typeprof.git
+  revision: d95ac88c4f629ad0955a485be348a8c981e9bc3d
+  specs:
+    typeprof (0.31.1)
+      prism (>= 1.4.0)
+      rbs (>= 3.6.0)
+
+GIT
+  remote: https://github.com/soutaro/steep.git
+  revision: 480d2288d3c560a51af5013780916d91cab34fe9
+  specs:
+    steep (2.0.0.dev)
+      activesupport (>= 5.1)
+      concurrent-ruby (>= 1.1.10)
+      csv (>= 3.0.9)
+      fileutils (>= 1.1.0)
+      json (>= 2.1.0)
+      language_server-protocol (>= 3.17.0.4, < 4.0)
+      listen (~> 3.0)
+      logger (>= 1.3.0)
+      parser (>= 3.2)
+      rainbow (>= 2.2.2, < 4.0)
+      rbs (~> 4.0.0.dev)
+      securerandom (>= 0.1)
+      strscan (>= 1.0.0)
+      terminal-table (>= 2, < 5)
+      uri (>= 0.12.0)
+
+PATH
+  remote: .
+  specs:
+    ruby-minify (0.2.0)
+      prism (>= 1.4.0)
+      rubocop
+      typeprof (>= 0.31.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activesupport (8.1.2.1)
+      base64
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.3.1)
+      connection_pool (>= 2.2.5)
+      drb
+      i18n (>= 1.6, < 2)
+      json
+      logger (>= 1.4.2)
+      minitest (>= 5.1)
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0, >= 2.0.5)
+      uri (>= 0.13.1)
+    ast (2.4.3)
+    base64 (0.3.0)
+    bigdecimal (4.0.1)
+    concurrent-ruby (1.3.6)
+    connection_pool (3.0.2)
+    csv (3.3.5)
+    date (3.5.1)
+    debug (1.11.1)
+      irb (~> 1.10)
+      reline (>= 0.3.8)
+    docile (1.4.1)
+    drb (2.2.3)
+    erb (6.0.2)
+    ffi (1.17.3)
+    ffi (1.17.3-aarch64-linux-gnu)
+    ffi (1.17.3-aarch64-linux-musl)
+    ffi (1.17.3-arm-linux-gnu)
+    ffi (1.17.3-arm-linux-musl)
+    ffi (1.17.3-arm64-darwin)
+    ffi (1.17.3-x86-linux-gnu)
+    ffi (1.17.3-x86-linux-musl)
+    ffi (1.17.3-x86_64-darwin)
+    ffi (1.17.3-x86_64-linux-gnu)
+    ffi (1.17.3-x86_64-linux-musl)
+    fileutils (1.8.0)
+    i18n (1.14.8)
+      concurrent-ruby (~> 1.0)
+    io-console (0.8.2)
+    irb (1.17.0)
+      pp (>= 0.6.0)
+      prism (>= 1.3.0)
+      rdoc (>= 4.0.0)
+      reline (>= 0.4.2)
+    json (2.19.2)
+    language_server-protocol (3.17.0.5)
+    lint_roller (1.1.0)
+    listen (3.10.0)
+      logger
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
+    logger (1.7.0)
+    minitest (6.0.2)
+      drb (~> 2.0)
+      prism (~> 1.5)
+    mustermann (3.0.4)
+      ruby2_keywords (~> 0.0.1)
+    parallel (1.27.0)
+    parser (3.3.10.2)
+      ast (~> 2.4.1)
+      racc
+    pp (0.6.3)
+      prettyprint
+    prettyprint (0.2.0)
+    prism (1.9.0)
+    psych (5.3.1)
+      date
+      stringio
+    racc (1.8.1)
+    rack (3.2.5)
+    rack-protection (4.2.1)
+      base64 (>= 0.1.0)
+      logger (>= 1.6.0)
+      rack (>= 3.0.0, < 4)
+    rack-session (2.1.1)
+      base64 (>= 0.1.0)
+      rack (>= 3.0.0)
+    rainbow (3.1.1)
+    rake (13.3.1)
+    rb-fsevent (0.11.2)
+    rb-inotify (0.11.1)
+      ffi (~> 1.0)
+    rbs (4.0.1)
+      logger
+      prism (>= 1.6.0)
+      tsort
+    rdoc (7.2.0)
+      erb
+      psych (>= 4.0.0)
+      tsort
+    regexp_parser (2.11.3)
+    reline (0.6.3)
+      io-console (~> 0.5)
+    rubocop (1.86.0)
+      json (~> 2.3)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.1.0)
+      parallel (~> 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 2.9.3, < 3.0)
+      rubocop-ast (>= 1.49.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 4.0)
+    rubocop-ast (1.49.1)
+      parser (>= 3.3.7.2)
+      prism (~> 1.7)
+    ruby-progressbar (1.13.0)
+    ruby2_keywords (0.0.5)
+    securerandom (0.4.1)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.13.2)
+    simplecov_json_formatter (0.1.4)
+    sinatra (4.2.1)
+      logger (>= 1.6.0)
+      mustermann (~> 3.0)
+      rack (>= 3.0.0, < 4)
+      rack-protection (= 4.2.1)
+      rack-session (>= 2.0.0, < 3)
+      tilt (~> 2.0)
+    stringio (3.2.0)
+    strscan (3.1.7)
+    terminal-table (4.0.0)
+      unicode-display_width (>= 1.1.1, < 4)
+    tilt (2.7.0)
+    tsort (0.2.0)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
+    unicode-display_width (3.2.0)
+      unicode-emoji (~> 4.1)
+    unicode-emoji (4.2.0)
+    uri (1.1.1)
+
+PLATFORMS
+  aarch64-linux-gnu
+  aarch64-linux-musl
+  arm-linux-gnu
+  arm-linux-musl
+  arm64-darwin
+  ruby
+  x86-linux-gnu
+  x86-linux-musl
+  x86_64-darwin
+  x86_64-linux-gnu
+  x86_64-linux-musl
+
+DEPENDENCIES
+  debug
+  minitest
+  rake (~> 13.0)
+  ruby-minify!
+  simplecov
+  sinatra
+  steep!
+  typeprof!
+
+CHECKSUMS
+  activesupport (8.1.2.1) sha256=beec20ced12ad569194554399449a6372fdab03061b8f48a9ed6ef9b7dc251b2
+  ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
+  base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
+  bigdecimal (4.0.1) sha256=8b07d3d065a9f921c80ceaea7c9d4ae596697295b584c296fe599dd0ad01c4a7
+  concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
+  connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
+  csv (3.3.5) sha256=6e5134ac3383ef728b7f02725d9872934f523cb40b961479f69cf3afa6c8e73f
+  date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
+  debug (1.11.1) sha256=2e0b0ac6119f2207a6f8ac7d4a73ca8eb4e440f64da0a3136c30343146e952b6
+  docile (1.4.1) sha256=96159be799bfa73cdb721b840e9802126e4e03dfc26863db73647204c727f21e
+  drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
+  erb (6.0.2) sha256=9fe6264d44f79422c87490a1558479bd0e7dad4dd0e317656e67ea3077b5242b
+  ffi (1.17.3) sha256=0e9f39f7bb3934f77ad6feab49662be77e87eedcdeb2a3f5c0234c2938563d4c
+  ffi (1.17.3-aarch64-linux-gnu) sha256=28ad573df26560f0aedd8a90c3371279a0b2bd0b4e834b16a2baa10bd7a97068
+  ffi (1.17.3-aarch64-linux-musl) sha256=020b33b76775b1abacc3b7d86b287cef3251f66d747092deec592c7f5df764b2
+  ffi (1.17.3-arm-linux-gnu) sha256=5bd4cea83b68b5ec0037f99c57d5ce2dd5aa438f35decc5ef68a7d085c785668
+  ffi (1.17.3-arm-linux-musl) sha256=0d7626bb96265f9af78afa33e267d71cfef9d9a8eb8f5525344f8da6c7d76053
+  ffi (1.17.3-arm64-darwin) sha256=0c690555d4cee17a7f07c04d59df39b2fba74ec440b19da1f685c6579bb0717f
+  ffi (1.17.3-x86-linux-gnu) sha256=868a88fcaf5186c3a46b7c7c2b2c34550e1e61a405670ab23f5b6c9971529089
+  ffi (1.17.3-x86-linux-musl) sha256=f0286aa6ef40605cf586e61406c446de34397b85dbb08cc99fdaddaef8343945
+  ffi (1.17.3-x86_64-darwin) sha256=1f211811eb5cfaa25998322cdd92ab104bfbd26d1c4c08471599c511f2c00bb5
+  ffi (1.17.3-x86_64-linux-gnu) sha256=3746b01f677aae7b16dc1acb7cb3cc17b3e35bdae7676a3f568153fb0e2c887f
+  ffi (1.17.3-x86_64-linux-musl) sha256=086b221c3a68320b7564066f46fed23449a44f7a1935f1fe5a245bd89d9aea56
+  fileutils (1.8.0) sha256=8c6b1df54e2540bdb2f39258f08af78853aa70bad52b4d394bbc6424593c6e02
+  i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
+  io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc
+  irb (1.17.0) sha256=168c4ddb93d8a361a045c41d92b2952c7a118fa73f23fe14e55609eb7a863aae
+  json (2.19.2) sha256=e7e1bd318b2c37c4ceee2444841c86539bc462e81f40d134cf97826cb14e83cf
+  language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
+  lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
+  listen (3.10.0) sha256=c6e182db62143aeccc2e1960033bebe7445309c7272061979bb098d03760c9d2
+  logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
+  minitest (6.0.2) sha256=db6e57956f6ecc6134683b4c87467d6dd792323c7f0eea7b93f66bd284adbc3d
+  mustermann (3.0.4) sha256=85fadcb6b3c6493a8b511b42426f904b7f27b282835502233dd154daab13aa22
+  parallel (1.27.0) sha256=4ac151e1806b755fb4e2dc2332cbf0e54f2e24ba821ff2d3dcf86bf6dc4ae130
+  parser (3.3.10.2) sha256=6f60c84aa4bdcedb6d1a2434b738fe8a8136807b6adc8f7f53b97da9bc4e9357
+  pp (0.6.3) sha256=2951d514450b93ccfeb1df7d021cae0da16e0a7f95ee1e2273719669d0ab9df6
+  prettyprint (0.2.0) sha256=2bc9e15581a94742064a3cc8b0fb9d45aae3d03a1baa6ef80922627a0766f193
+  prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
+  psych (5.3.1) sha256=eb7a57cef10c9d70173ff74e739d843ac3b2c019a003de48447b2963d81b1974
+  racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
+  rack (3.2.5) sha256=4cbd0974c0b79f7a139b4812004a62e4c60b145cba76422e288ee670601ed6d3
+  rack-protection (4.2.1) sha256=cf6e2842df8c55f5e4d1a4be015e603e19e9bc3a7178bae58949ccbb58558bac
+  rack-session (2.1.1) sha256=0b6dc07dea7e4b583f58a48e8b806d4c9f1c6c9214ebc202ec94562cbea2e4e9
+  rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
+  rake (13.3.1) sha256=8c9e89d09f66a26a01264e7e3480ec0607f0c497a861ef16063604b1b08eb19c
+  rb-fsevent (0.11.2) sha256=43900b972e7301d6570f64b850a5aa67833ee7d87b458ee92805d56b7318aefe
+  rb-inotify (0.11.1) sha256=a0a700441239b0ff18eb65e3866236cd78613d6b9f78fea1f9ac47a85e47be6e
+  rbs (4.0.1) sha256=e237fd49787fb265bf0f389f2f0f5788fdcdf1f49bb54b4f7952cea904162a07
+  rdoc (7.2.0) sha256=8650f76cd4009c3b54955eb5d7e3a075c60a57276766ebf36f9085e8c9f23192
+  regexp_parser (2.11.3) sha256=ca13f381a173b7a93450e53459075c9b76a10433caadcb2f1180f2c741fc55a4
+  reline (0.6.3) sha256=1198b04973565b36ec0f11542ab3f5cfeeec34823f4e54cebde90968092b1835
+  rubocop (1.86.0) sha256=4ff1186fe16ebe9baff5e7aad66bb0ad4cabf5cdcd419f773146dbba2565d186
+  rubocop-ast (1.49.1) sha256=4412f3ee70f6fe4546cc489548e0f6fcf76cafcfa80fa03af67098ffed755035
+  ruby-minify (0.2.0)
+  ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
+  ruby2_keywords (0.0.5) sha256=ffd13740c573b7301cf7a2e61fc857b2a8e3d3aff32545d6f8300d8bae10e3ef
+  securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
+  simplecov (0.22.0) sha256=fe2622c7834ff23b98066bb0a854284b2729a569ac659f82621fc22ef36213a5
+  simplecov-html (0.13.2) sha256=bd0b8e54e7c2d7685927e8d6286466359b6f16b18cb0df47b508e8d73c777246
+  simplecov_json_formatter (0.1.4) sha256=529418fbe8de1713ac2b2d612aa3daa56d316975d307244399fa4838c601b428
+  sinatra (4.2.1) sha256=b7aeb9b11d046b552972ade834f1f9be98b185fa8444480688e3627625377080
+  steep (2.0.0.dev)
+  stringio (3.2.0) sha256=c37cb2e58b4ffbd33fe5cd948c05934af997b36e0b6ca6fdf43afa234cf222e1
+  strscan (3.1.7) sha256=5f76462b94a3ea50b44973225b7d75b2cb96d4e1bee9ef1319b99ca117b72c8c
+  terminal-table (4.0.0) sha256=f504793203f8251b2ea7c7068333053f0beeea26093ec9962e62ea79f94301d2
+  tilt (2.7.0) sha256=0d5b9ba69f6a36490c64b0eee9f6e9aad517e20dcc848800a06eb116f08c6ab3
+  tsort (0.2.0) sha256=9650a793f6859a43b6641671278f79cfead60ac714148aabe4e3f0060480089f
+  typeprof (0.31.1)
+  tzinfo (2.0.6) sha256=8daf828cc77bcf7d63b0e3bdb6caa47e2272dcfaf4fbfe46f8c3a9df087a829b
+  unicode-display_width (3.2.0) sha256=0cdd96b5681a5949cdbc2c55e7b420facae74c4aaf9a9815eee1087cb1853c42
+  unicode-emoji (4.2.0) sha256=519e69150f75652e40bf736106cfbc8f0f73aa3fb6a65afe62fefa7f80b0f80f
+  uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
+
+BUNDLED WITH
+  4.0.6

--- a/Gemfile.gems_test.lock
+++ b/Gemfile.gems_test.lock
@@ -193,6 +193,7 @@ DEPENDENCIES
   debug
   minitest
   rake (~> 13.0)
+  rubocop
   ruby-minify!
   simplecov
   sinatra

--- a/lib/ruby_minify/minifier.rb
+++ b/lib/ruby_minify/minifier.rb
@@ -166,15 +166,18 @@ module RubyMinify
       parts.join(';')
     end
 
-    MAX_LINE_LENGTH = 100_000
+    MAX_LINE_LENGTH = 10_000
 
     def break_long_lines(code)
       return code unless code.lines.any? { |l| l.size > MAX_LINE_LENGTH }
 
+      sep = ";" + "end" + ";"
       result = +""
       code.each_line do |line|
-        if line.size > MAX_LINE_LENGTH
-          result << line.gsub(";" + "end" + ";", ";" + "end" + "\n")
+        if line.size > MAX_LINE_LENGTH && line.include?(sep)
+          result << line.gsub(sep, ";" + "end" + "\n")
+        elsif line.size > MAX_LINE_LENGTH
+          result << line.gsub(";") { ";\n" }
         else
           result << line
         end

--- a/lib/ruby_minify/minifier.rb
+++ b/lib/ruby_minify/minifier.rb
@@ -141,6 +141,7 @@ module RubyMinify
 
     def build_result(rename_result, source)
       content = build_output(rename_result.code, source.stdlib_requires, rename_result.preamble)
+      content = break_long_lines(content)
       size = content.bytesize
 
       stats = Pipeline::CompressionStats.new(
@@ -163,6 +164,14 @@ module RubyMinify
       parts << preamble unless preamble.empty?
       parts << code
       parts.join(';')
+    end
+
+    MAX_LINE_LENGTH = 100_000
+
+    def break_long_lines(code)
+      return code unless code.lines.any? { |l| l.size > MAX_LINE_LENGTH }
+
+      code.gsub(/;end;/) { ";end\n" }
     end
   end
 end

--- a/lib/ruby_minify/minifier.rb
+++ b/lib/ruby_minify/minifier.rb
@@ -177,7 +177,7 @@ module RubyMinify
         if line.size > MAX_LINE_LENGTH && line.include?(sep)
           result << line.gsub(sep, ";" + "end" + "\n")
         elsif line.size > MAX_LINE_LENGTH
-          result << line.gsub(";") { ";\n" }
+          result << line.gsub(";", ";\n")
         else
           result << line
         end

--- a/lib/ruby_minify/minifier.rb
+++ b/lib/ruby_minify/minifier.rb
@@ -171,7 +171,15 @@ module RubyMinify
     def break_long_lines(code)
       return code unless code.lines.any? { |l| l.size > MAX_LINE_LENGTH }
 
-      code.gsub(/;end;/) { ";end\n" }
+      result = +""
+      code.each_line do |line|
+        if line.size > MAX_LINE_LENGTH
+          result << line.gsub(";" + "end" + ";", ";" + "end" + "\n")
+        else
+          result << line
+        end
+      end
+      result
     end
   end
 end

--- a/tests/test_gem_minification.rb
+++ b/tests/test_gem_minification.rb
@@ -8,12 +8,13 @@ require_relative '../lib/ruby_minify'
 
 # Test that minified gems pass their own test suites.
 # Excluded from default `rake test` — run with `rake test:gems`.
+# Requires BUNDLE_GEMFILE=Gemfile.gems_test so target gems are available.
 class TestGemMinification < Minitest::Test
   GEM_TESTS_DIR = File.expand_path('../gem_tests', __dir__)
 
   GEMS = {
     sinatra: {
-      source: 'sinatra/lib/sinatra/base.rb',
+      gem_name: 'sinatra',
       test_files: %w[
         sinatra/test/routing_test.rb
         sinatra/test/helpers_test.rb
@@ -54,14 +55,11 @@ class TestGemMinification < Minitest::Test
         sinatra/test/slim_test.rb
         sinatra/test/yajl_test.rb
       ],
-      lib_name: 'sinatra/base',
-      extra_includes: ['sinatra/rack-protection/lib'],
-      copy_files: %w[sinatra/lib/sinatra/middleware sinatra/lib/sinatra/version.rb sinatra/lib/sinatra/show_exceptions.rb sinatra/lib/sinatra/indifferent_hash.rb],
       min_level: 3,
-      max_level: 3,  # L4+ has class/method renaming issues with sinatra
+      max_level: 3,
     },
     rubocop: {
-      source: 'rubocop/lib/rubocop.rb',
+      gem_name: 'rubocop',
       test_file_patterns: ['rubocop/spec/rubocop/**/*_spec.rb'],
       exclude_test_patterns: %w[
         rubocop/spec/rubocop/server/**/*_spec.rb
@@ -75,53 +73,36 @@ class TestGemMinification < Minitest::Test
         rubocop/spec/rubocop/mcp/server_spec.rb
         rubocop/spec/rubocop/runner_formatter_invocation_spec.rb
       ],
-      lib_name: 'rubocop',
       test_runner: :rspec,
-      gem_dir: 'rubocop',
-      copy_files: %w[rubocop/lib/rubocop/cop/internal_affairs rubocop/lib/rubocop/cop/internal_affairs.rb rubocop/lib/rubocop/server.rb rubocop/lib/rubocop/server rubocop/lib/rubocop/rspec],
-      file_depth: 2,
-      project_files: %w[rubocop/config],
       min_level: 3,
-      max_level: 3  # L4+ constant aliasing breaks rubocop's cop registry
+      max_level: 3,
     }
   }.freeze
 
-  GEMS.each do |gem_name, config|
+  GEMS.each do |gem_key, config|
     min_level = config[:min_level] || 0
     max_level = config[:max_level] || 5
     (min_level..max_level).each do |level|
-      define_method(:"test_#{gem_name}_level#{level}") do
-        source_path = File.join(GEM_TESTS_DIR, config[:source])
-        test_files = Array(config[:test_files] || config[:test_file]).map { |f| File.join(GEM_TESTS_DIR, f) }
-        if config[:test_file_patterns]
-          excludes = Array(config[:exclude_test_files]).map { |f| File.join(GEM_TESTS_DIR, f) }
-          Array(config[:exclude_test_patterns]).each do |pat|
-            excludes.concat(Dir.glob(File.join(GEM_TESTS_DIR, pat)))
-          end
-          config[:test_file_patterns].each do |pattern|
-            test_files.concat(Dir.glob(File.join(GEM_TESTS_DIR, pattern)) - excludes)
-          end
-          test_files.uniq!
+      define_method(:"test_#{gem_key}_level#{level}") do
+        gem_name = config[:gem_name]
+
+        begin
+          resolution = RubyMinify::GemResolver.new.call(gem_name)
+        rescue RubyMinify::Pipeline::GemNotFoundError
+          skip "#{gem_name} gem not available (use BUNDLE_GEMFILE=Gemfile.gems_test)"
         end
-        skip "gem source not found: #{source_path}" unless File.exist?(source_path)
+
+        test_files = resolve_test_files(config)
+        skip "no test files found for #{gem_name} (clone repos into gem_tests/)" if test_files.empty?
         test_files.each { |f| skip "gem test not found: #{f}" unless File.exist?(f) }
 
-        extra_includes = (config[:extra_includes] || []).map { |p| File.join(GEM_TESTS_DIR, p) }
-        copy_files = (config[:copy_files] || []).map { |p| File.join(GEM_TESTS_DIR, p) }
-        project_files = (config[:project_files] || []).map { |p| File.join(GEM_TESTS_DIR, p) }
-        gem_dir = config[:gem_dir] ? File.join(GEM_TESTS_DIR, config[:gem_dir]) : nil
+        gem_dir = File.join(GEM_TESTS_DIR, gem_key.to_s)
         assert_minified_gem_passes(
-          source_path: source_path,
+          resolution: resolution,
           test_files: test_files,
-          lib_name: config[:lib_name],
-          lib_dir: File.join(GEM_TESTS_DIR, File.dirname(config[:source])),
           level: level,
-          gem_name: gem_name,
-          extra_includes: extra_includes,
-          copy_files: copy_files,
+          gem_name: gem_key,
           test_runner: config[:test_runner],
-          file_depth: config[:file_depth] || 0,
-          project_files: project_files,
           gem_dir: gem_dir
         )
       end
@@ -130,42 +111,42 @@ class TestGemMinification < Minitest::Test
 
   private
 
-  def assert_minified_gem_passes(source_path:, test_files:, lib_name:, lib_dir:, level:, gem_name:, extra_includes: [], copy_files: [], test_runner: nil, file_depth: 0, project_files: [], gem_dir: nil)
-    # Run baseline (original code) to find environment-specific failures
-    baseline_failures = baseline_failures_for(gem_name, test_files, lib_dir,
-                                               extra_includes: extra_includes, test_runner: test_runner, gem_dir: gem_dir)
+  def resolve_test_files(config)
+    test_files = Array(config[:test_files]).map { |f| File.join(GEM_TESTS_DIR, f) }
+    if config[:test_file_patterns]
+      excludes = Array(config[:exclude_test_files]).map { |f| File.join(GEM_TESTS_DIR, f) }
+      Array(config[:exclude_test_patterns]).each do |pat|
+        excludes.concat(Dir.glob(File.join(GEM_TESTS_DIR, pat)))
+      end
+      config[:test_file_patterns].each do |pattern|
+        test_files.concat(Dir.glob(File.join(GEM_TESTS_DIR, pattern)) - excludes)
+      end
+      test_files.uniq!
+    end
+    test_files
+  end
+
+  def assert_minified_gem_passes(resolution:, test_files:, level:, gem_name:, test_runner: nil, gem_dir: nil)
+    baseline_failures = baseline_failures_for(gem_name, test_files, resolution, test_runner: test_runner, gem_dir: gem_dir)
 
     minifier = RubyMinify::Minifier.new
-    result = minifier.call(source_path, level: level)
+    result = minifier.call(
+      resolution.entry_path,
+      level: level,
+      project_root: resolution.project_root,
+      gem_names: [gem_name.to_s],
+      gem_require_paths: resolution.require_paths
+    )
 
-    content = if result.aliases.empty?
-      result.content
-    else
-      "#{result.content};#{result.aliases}"
-    end
+    content = result.aliases.empty? ? result.content : "#{result.content};#{result.aliases}"
 
     Dir.mktmpdir("minify_gem_test") do |tmpdir|
-      # file_depth: nest the minified file N levels deep so __FILE__-relative
-      # paths (e.g., RUBOCOP_HOME = File.dirname(__FILE__)/../..) resolve correctly
-      if file_depth > 0
-        nested_dir = File.join(tmpdir, *Array.new(file_depth, 'x'))
-        FileUtils.mkdir_p(nested_dir)
-        minified_path = File.join(nested_dir, "#{lib_name}.rb")
-        actual_lib_dir = nested_dir
-      else
-        minified_path = File.join(tmpdir, "#{lib_name}.rb")
-        actual_lib_dir = tmpdir
-      end
+      relative = resolution.entry_path.delete_prefix("#{resolution.require_paths.first}/")
+      minified_path = File.join(tmpdir, relative)
       FileUtils.mkdir_p(File.dirname(minified_path))
       File.write(minified_path, content)
 
-      gem_root = File.expand_path('..', File.dirname(source_path))
-      project_files.each { |src| copy_relative(src, gem_root, tmpdir) }
-      copy_files.each { |src| copy_relative(src, File.dirname(source_path), File.dirname(minified_path)) }
-      # Create stub files for require_relative targets in copied files that
-      # don't exist (their code is already in the minified output)
-      create_require_stubs(File.dirname(minified_path))
-      minified = run_gem_tests(test_files, actual_lib_dir, extra_includes: extra_includes, test_runner: test_runner, gem_dir: gem_dir)
+      minified = run_gem_tests(test_files, tmpdir, test_runner: test_runner, gem_dir: gem_dir)
       minified_count = parse_test_count(minified[:stdout])
       assert minified_count,
         "#{gem_name} L#{level}: no test summary found (minified code likely crashed)\nstderr: #{minified[:stderr][0, 300]}"
@@ -177,11 +158,11 @@ class TestGemMinification < Minitest::Test
     end
   end
 
-  def baseline_failures_for(gem_name, test_files, lib_dir, extra_includes: [], test_runner: nil, gem_dir: nil)
+  def baseline_failures_for(gem_name, test_files, resolution, test_runner: nil, gem_dir: nil)
     cache = self.class.baseline_cache
     return cache[gem_name] if cache.key?(gem_name)
 
-    baseline = run_gem_tests(test_files, lib_dir, extra_includes: extra_includes, test_runner: test_runner, gem_dir: gem_dir)
+    baseline = run_gem_tests(test_files, resolution.require_paths.first, test_runner: test_runner, gem_dir: gem_dir)
     cache[gem_name] = parse_test_result(baseline[:stdout])
   end
 
@@ -189,19 +170,15 @@ class TestGemMinification < Minitest::Test
     @baseline_cache ||= {}
   end
 
-  def run_gem_tests(test_files, lib_dir, extra_includes: [], test_runner: nil, gem_dir: nil)
+  def run_gem_tests(test_files, lib_dir, test_runner: nil, gem_dir: nil)
     test_files = Array(test_files)
-    include_args = ["-I", lib_dir] + extra_includes.flat_map { |p| ["-I", p] }
+    include_args = ["-I", lib_dir]
 
     if test_runner == :rspec
       args = build_rspec_args(test_files, lib_dir, include_args)
     elsif test_files.size == 1
       args = [*include_args, test_files.first]
     else
-      # Multiple test files: use a runner script that keeps lib_dir at the
-      # front of $LOAD_PATH even if test helpers prepend their own lib dirs.
-      # Without this, gems like sinatra whose test_helper does
-      # $LOAD_PATH.unshift(original_lib) would bypass our minified lib.
       runner = Tempfile.new(['gem_test_runner', '.rb'])
       runner.write(<<~RUBY)
         minified_lib = #{lib_dir.inspect}
@@ -219,8 +196,6 @@ class TestGemMinification < Minitest::Test
       runner.flush
       args = [*include_args, runner.path]
     end
-    # Use temp files instead of Open3.capture3 to avoid pipe buffer
-    # deadlocks when test output is very large (e.g. 30k+ rspec examples)
     stdout_file = Tempfile.new('gem_test_stdout')
     stderr_file = Tempfile.new('gem_test_stderr')
     stdout_file.close
@@ -279,35 +254,9 @@ class TestGemMinification < Minitest::Test
     nil
   end
 
-  def copy_relative(src, base_from, base_to)
-    relative = src.sub(base_from + '/', '')
-    dst = File.join(base_to, relative)
-    FileUtils.mkdir_p(File.dirname(dst))
-    if File.directory?(src)
-      FileUtils.cp_r(src, dst)
-    else
-      FileUtils.cp(src, dst)
-    end
-  end
-
-  def create_require_stubs(base_dir)
-    Dir.glob(File.join(base_dir, '**', '*.rb')).each do |file|
-      File.read(file).scan(/require_relative\s+['"]([^'"]+)['"]/).each do |match|
-        rel_path = match[0]
-        target = File.expand_path(rel_path, File.dirname(file))
-        target += '.rb' unless target.end_with?('.rb')
-        next if File.exist?(target)
-        FileUtils.mkdir_p(File.dirname(target))
-        File.write(target, "# stub: code already in minified output\n")
-      end
-    end
-  end
-
   def parse_test_count(output)
-    # minitest: "5 runs, ..." / test-unit: "27 tests, ..."
     if output =~ /(\d+) (?:runs?|tests?),/
       $1.to_i
-    # rspec: "1028 examples, 0 failures"
     elsif output =~ /(\d+) examples?,/
       $1.to_i
     end
@@ -316,17 +265,14 @@ class TestGemMinification < Minitest::Test
   def parse_test_result(output)
     failures = []
 
-    # test/unit format: "Failure: test_name(ClassName)" or "Error: test_name(ClassName): ..."
     output.scan(/^(?:Failure|Error): (\S+)\((\S+)\)/) do |test_name, klass|
       failures << "#{klass}##{test_name}"
     end
 
-    # minitest format: "  1) Failure:\nTestClass#test_name [path:line]:"
     output.scan(/^\s+\d+\) (?:Failure|Error):\n(\S+#\S+)/) do |match|
       failures << match[0]
     end
 
-    # rspec format: "rspec ./spec/path/file_spec.rb:42 # Description text"
     output.scan(/^rspec (\S+:\d+)/) do |match|
       failures << match[0]
     end

--- a/tests/test_gem_minification.rb
+++ b/tests/test_gem_minification.rb
@@ -4,6 +4,7 @@ require 'minitest/autorun'
 require 'tempfile'
 require 'fileutils'
 require 'rbconfig'
+require 'securerandom'
 require_relative '../lib/ruby_minify'
 
 # Test that minified gems pass their own test suites.
@@ -143,6 +144,8 @@ class TestGemMinification < Minitest::Test
     )
 
     content = result.aliases.empty? ? result.content : "#{result.content};#{result.aliases}"
+    marker = "RUBY_MINIFY_MARKER_#{SecureRandom.hex(8)}"
+    content = "#{marker}=true;#{content}"
 
     Dir.mktmpdir("minify_gem_test") do |tmpdir|
       matching_root = resolution.require_paths.detect { |p| resolution.entry_path.start_with?("#{p}/") }
@@ -154,7 +157,8 @@ class TestGemMinification < Minitest::Test
 
       $stderr.puts "[#{gem_name}] Running minified L#{level} tests..."
       minified = run_gem_tests(test_files, tmpdir, test_runner: test_runner, gem_dir: gem_dir,
-                               test_gemfile: test_gemfile, replace_paths: resolution.require_paths)
+                               test_gemfile: test_gemfile, replace_paths: resolution.require_paths,
+                               marker: marker)
       minified_count = parse_test_count(minified[:stdout])
       $stderr.puts "[#{gem_name}] Minified L#{level}: #{minified_count || 'NO RESULT'} tests"
       assert minified_count,
@@ -182,7 +186,7 @@ class TestGemMinification < Minitest::Test
     @baseline_cache ||= {}
   end
 
-  def run_gem_tests(test_files, lib_dir, test_runner: nil, gem_dir: nil, test_gemfile: 'Gemfile', replace_paths: [])
+  def run_gem_tests(test_files, lib_dir, test_runner: nil, gem_dir: nil, test_gemfile: 'Gemfile', replace_paths: [], marker: nil)
     test_files = Array(test_files)
     include_args = lib_dir ? ["-I", lib_dir] : []
 
@@ -190,6 +194,9 @@ class TestGemMinification < Minitest::Test
     setup_code = if replace_paths.any? && lib_dir
       lines = replace_paths.map { |p| "$LOAD_PATH.delete(#{p.inspect})" }
       lines << "$LOAD_PATH.unshift(#{lib_dir.inspect}) unless $LOAD_PATH[0] == #{lib_dir.inspect}"
+      if marker
+        lines << "at_exit { abort %q(MINIFY_MARKER_MISSING: loaded non-minified code!) unless defined?(#{marker}) }"
+      end
       lines.join('; ')
     end
 

--- a/tests/test_gem_minification.rb
+++ b/tests/test_gem_minification.rb
@@ -222,11 +222,10 @@ class TestGemMinification < Minitest::Test
     else
       File.dirname(test_files.first)
     end
-    gem_gemfile = gem_dir ? File.join(gem_dir, 'Gemfile') : nil
+    gem_gemfile = gem_dir ? File.expand_path('Gemfile', gem_dir) : nil
     pid = Bundler.with_unbundled_env do
-      env = {}
+      env = { 'BUNDLE_GEMFILE' => gem_gemfile }
       if gem_gemfile && File.exist?(gem_gemfile)
-        env['BUNDLE_GEMFILE'] = gem_gemfile
         cmd = ['bundle', 'exec', RbConfig.ruby, *args]
       else
         cmd = [RbConfig.ruby, *args]

--- a/tests/test_gem_minification.rb
+++ b/tests/test_gem_minification.rb
@@ -262,7 +262,9 @@ class TestGemMinification < Minitest::Test
       { stdout: File.read(stdout_file.path), stderr: "TIMEOUT after #{timeout}s\n" + File.read(stderr_file.path), status: nil }
     end
   ensure
+    stdout_file&.close
     stdout_file&.unlink
+    stderr_file&.close
     stderr_file&.unlink
     runner&.close!
     @rspec_runner&.close!

--- a/tests/test_gem_minification.rb
+++ b/tests/test_gem_minification.rb
@@ -168,7 +168,7 @@ class TestGemMinification < Minitest::Test
     cache = self.class.baseline_cache
     return cache[gem_name] if cache.key?(gem_name)
 
-    baseline = run_gem_tests(test_files, resolution.require_paths.first, test_runner: test_runner, gem_dir: gem_dir, test_gemfile: test_gemfile)
+    baseline = run_gem_tests(test_files, nil, test_runner: test_runner, gem_dir: gem_dir, test_gemfile: test_gemfile)
     cache[gem_name] = parse_test_result(baseline[:stdout])
   end
 
@@ -178,10 +178,10 @@ class TestGemMinification < Minitest::Test
 
   def run_gem_tests(test_files, lib_dir, test_runner: nil, gem_dir: nil, test_gemfile: 'Gemfile', replace_paths: [])
     test_files = Array(test_files)
-    include_args = ["-I", lib_dir]
+    include_args = lib_dir ? ["-I", lib_dir] : []
 
     # Build a setup preamble that removes original gem paths and keeps lib_dir at front
-    setup_code = if replace_paths.any?
+    setup_code = if replace_paths.any? && lib_dir
       lines = replace_paths.map { |p| "$LOAD_PATH.delete(#{p.inspect})" }
       lines << "$LOAD_PATH.unshift(#{lib_dir.inspect}) unless $LOAD_PATH[0] == #{lib_dir.inspect}"
       lines.join('; ')
@@ -197,20 +197,24 @@ class TestGemMinification < Minitest::Test
       end
     else
       runner = Tempfile.new(['gem_test_runner', '.rb'])
-      preamble = setup_code ? "#{setup_code}\n" : ""
-      runner.write(<<~RUBY)
-        #{preamble}minified_lib = #{lib_dir.inspect}
-        original_unshift = $LOAD_PATH.method(:unshift)
-        $LOAD_PATH.define_singleton_method(:unshift) do |*args|
-          original_unshift.call(*args)
-          if $LOAD_PATH.index(minified_lib) != 0
-            $LOAD_PATH.delete(minified_lib)
-            original_unshift.call(minified_lib)
+      if setup_code
+        runner.write(<<~RUBY)
+          #{setup_code}
+          minified_lib = #{lib_dir.inspect}
+          original_unshift = $LOAD_PATH.method(:unshift)
+          $LOAD_PATH.define_singleton_method(:unshift) do |*args|
+            original_unshift.call(*args)
+            if $LOAD_PATH.index(minified_lib) != 0
+              $LOAD_PATH.delete(minified_lib)
+              original_unshift.call(minified_lib)
+            end
+            self
           end
-          self
-        end
-        #{test_files.map { |f| "require #{f.inspect}" }.join("\n")}
-      RUBY
+          #{test_files.map { |f| "require #{f.inspect}" }.join("\n")}
+        RUBY
+      else
+        runner.write(test_files.map { |f| "require #{f.inspect}" }.join("\n"))
+      end
       runner.flush
       args = [*include_args, runner.path]
     end
@@ -263,7 +267,7 @@ class TestGemMinification < Minitest::Test
     runner = Tempfile.new(['rspec_runner', '.rb'])
     preamble = setup_code ? "#{setup_code}\n" : ""
     runner.write(<<~RUBY)
-      #{preamble}$LOAD_PATH.unshift(#{spec_dir.inspect}) if #{spec_dir.inspect}
+      #{preamble}$LOAD_PATH.unshift(#{spec_dir.inspect}) if #{!spec_dir.nil?}
       require "rspec/core"
       exit(RSpec::Core::Runner.run(#{test_files.inspect} + ["--format", "progress", "--order", "defined", "--require", "spec_helper"]))
     RUBY

--- a/tests/test_gem_minification.rb
+++ b/tests/test_gem_minification.rb
@@ -59,7 +59,8 @@ class TestGemMinification < Minitest::Test
       min_level: 3,
       max_level: 3,
     },
-    # rubocop: disabled — L3 minification still produces 2 duplicated argument name errors.
+    # rubocop: disabled — preamble references unresolved top-level constants (e.g. E=NodePattern).
+    # See: https://github.com/ahogappa/ruby-minify/issues/18
     # rubocop: {
     #   gem_name: 'rubocop',
     #   test_file_patterns: ['rubocop/spec/rubocop/**/*_spec.rb'],
@@ -159,7 +160,7 @@ class TestGemMinification < Minitest::Test
       $stderr.puts "[#{gem_name}] Minified L#{level}: #{minified_count || 'NO RESULT'} tests"
       assert minified_count,
         "#{gem_name} L#{level}: no test summary found (minified code likely crashed)\nstderr: #{minified[:stderr][0, 300]}"
-      assert minified_count > 0, "#{gem_name} L#{level}: 0 tests ran"
+      assert minified_count > 0, "#{gem_name} L#{level}: 0 tests ran\nstdout: #{minified[:stdout][0, 500]}\nstderr: #{minified[:stderr][0, 500]}"
       minified_failures = parse_test_result(minified[:stdout])
       new_failures = minified_failures - baseline_failures
       assert new_failures.empty?,

--- a/tests/test_gem_minification.rb
+++ b/tests/test_gem_minification.rb
@@ -59,8 +59,7 @@ class TestGemMinification < Minitest::Test
       min_level: 3,
       max_level: 3,
     },
-    # rubocop: disabled — L3 minification produces syntax errors (duplicated argument names).
-    # See: https://github.com/ahogappa/ruby-minify/issues/TODO
+    # rubocop: disabled — L3 minification still produces 2 duplicated argument name errors.
     # rubocop: {
     #   gem_name: 'rubocop',
     #   test_file_patterns: ['rubocop/spec/rubocop/**/*_spec.rb'],

--- a/tests/test_gem_minification.rb
+++ b/tests/test_gem_minification.rb
@@ -151,9 +151,11 @@ class TestGemMinification < Minitest::Test
       FileUtils.mkdir_p(File.dirname(minified_path))
       File.write(minified_path, content)
 
+      $stderr.puts "[#{gem_name}] Running minified L#{level} tests..."
       minified = run_gem_tests(test_files, tmpdir, test_runner: test_runner, gem_dir: gem_dir,
                                test_gemfile: test_gemfile, replace_paths: resolution.require_paths)
       minified_count = parse_test_count(minified[:stdout])
+      $stderr.puts "[#{gem_name}] Minified L#{level}: #{minified_count || 'NO RESULT'} tests"
       assert minified_count,
         "#{gem_name} L#{level}: no test summary found (minified code likely crashed)\nstderr: #{minified[:stderr][0, 300]}"
       assert minified_count > 0, "#{gem_name} L#{level}: 0 tests ran"
@@ -168,7 +170,10 @@ class TestGemMinification < Minitest::Test
     cache = self.class.baseline_cache
     return cache[gem_name] if cache.key?(gem_name)
 
+    $stderr.puts "[#{gem_name}] Running baseline tests..."
     baseline = run_gem_tests(test_files, nil, test_runner: test_runner, gem_dir: gem_dir, test_gemfile: test_gemfile)
+    $stderr.puts "[#{gem_name}] Baseline: #{parse_test_count(baseline[:stdout]) || 'NO RESULT'} tests"
+    $stderr.puts "[#{gem_name}] Baseline stderr: #{baseline[:stderr][0, 200]}" unless baseline[:stderr].empty?
     cache[gem_name] = parse_test_result(baseline[:stdout])
   end
 
@@ -245,7 +250,7 @@ class TestGemMinification < Minitest::Test
         err: [stderr_file.path, 'w']
       )
     end
-    timeout = test_files.size > 10 ? 600 : 120
+    timeout = test_files.size > 10 ? 180 : 120
     waiter = Thread.new { Process.wait2(pid) }
     if waiter.join(timeout)
       { stdout: File.read(stdout_file.path), stderr: File.read(stderr_file.path), status: waiter.value[1] }

--- a/tests/test_gem_minification.rb
+++ b/tests/test_gem_minification.rb
@@ -148,7 +148,8 @@ class TestGemMinification < Minitest::Test
       FileUtils.mkdir_p(File.dirname(minified_path))
       File.write(minified_path, content)
 
-      minified = run_gem_tests(test_files, tmpdir, test_runner: test_runner, gem_dir: gem_dir)
+      minified = run_gem_tests(test_files, tmpdir, test_runner: test_runner, gem_dir: gem_dir,
+                               replace_paths: resolution.require_paths)
       minified_count = parse_test_count(minified[:stdout])
       assert minified_count,
         "#{gem_name} L#{level}: no test summary found (minified code likely crashed)\nstderr: #{minified[:stderr][0, 300]}"
@@ -172,18 +173,30 @@ class TestGemMinification < Minitest::Test
     @baseline_cache ||= {}
   end
 
-  def run_gem_tests(test_files, lib_dir, test_runner: nil, gem_dir: nil)
+  def run_gem_tests(test_files, lib_dir, test_runner: nil, gem_dir: nil, replace_paths: [])
     test_files = Array(test_files)
     include_args = ["-I", lib_dir]
 
+    # Build a setup preamble that removes original gem paths and keeps lib_dir at front
+    setup_code = if replace_paths.any?
+      lines = replace_paths.map { |p| "$LOAD_PATH.delete(#{p.inspect})" }
+      lines << "$LOAD_PATH.unshift(#{lib_dir.inspect}) unless $LOAD_PATH[0] == #{lib_dir.inspect}"
+      lines.join('; ')
+    end
+
     if test_runner == :rspec
-      args = build_rspec_args(test_files, lib_dir, include_args)
+      args = build_rspec_args(test_files, lib_dir, include_args, setup_code: setup_code)
     elsif test_files.size == 1
-      args = [*include_args, test_files.first]
+      if setup_code
+        args = [*include_args, "-e", "#{setup_code}; load #{test_files.first.inspect}"]
+      else
+        args = [*include_args, test_files.first]
+      end
     else
       runner = Tempfile.new(['gem_test_runner', '.rb'])
+      preamble = setup_code ? "#{setup_code}\n" : ""
       runner.write(<<~RUBY)
-        minified_lib = #{lib_dir.inspect}
+        #{preamble}minified_lib = #{lib_dir.inspect}
         original_unshift = $LOAD_PATH.method(:unshift)
         $LOAD_PATH.define_singleton_method(:unshift) do |*args|
           original_unshift.call(*args)
@@ -243,11 +256,12 @@ class TestGemMinification < Minitest::Test
     @rspec_runner = nil
   end
 
-  def build_rspec_args(test_files, lib_dir, include_args)
+  def build_rspec_args(test_files, lib_dir, include_args, setup_code: nil)
     spec_dir = find_spec_dir(test_files.first)
     runner = Tempfile.new(['rspec_runner', '.rb'])
+    preamble = setup_code ? "#{setup_code}\n" : ""
     runner.write(<<~RUBY)
-      $LOAD_PATH.unshift(#{spec_dir.inspect}) if #{spec_dir.inspect}
+      #{preamble}$LOAD_PATH.unshift(#{spec_dir.inspect}) if #{spec_dir.inspect}
       require "rspec/core"
       exit(RSpec::Core::Runner.run(#{test_files.inspect} + ["--format", "progress", "--order", "defined", "--require", "spec_helper"]))
     RUBY

--- a/tests/test_gem_minification.rb
+++ b/tests/test_gem_minification.rb
@@ -15,6 +15,7 @@ class TestGemMinification < Minitest::Test
   GEMS = {
     sinatra: {
       gem_name: 'sinatra',
+      test_gemfile: 'Gemfile.test',
       test_files: %w[
         sinatra/test/routing_test.rb
         sinatra/test/helpers_test.rb
@@ -97,13 +98,15 @@ class TestGemMinification < Minitest::Test
         test_files.each { |f| skip "gem test not found: #{f}" unless File.exist?(f) }
 
         gem_dir = File.join(GEM_TESTS_DIR, gem_key.to_s)
+        test_gemfile = config[:test_gemfile] || 'Gemfile'
         assert_minified_gem_passes(
           resolution: resolution,
           test_files: test_files,
           level: level,
           gem_name: gem_name,
           test_runner: config[:test_runner],
-          gem_dir: gem_dir
+          gem_dir: gem_dir,
+          test_gemfile: test_gemfile
         )
       end
     end
@@ -126,8 +129,8 @@ class TestGemMinification < Minitest::Test
     test_files
   end
 
-  def assert_minified_gem_passes(resolution:, test_files:, level:, gem_name:, test_runner: nil, gem_dir: nil)
-    baseline_failures = baseline_failures_for(gem_name, test_files, resolution, test_runner: test_runner, gem_dir: gem_dir)
+  def assert_minified_gem_passes(resolution:, test_files:, level:, gem_name:, test_runner: nil, gem_dir: nil, test_gemfile: 'Gemfile')
+    baseline_failures = baseline_failures_for(gem_name, test_files, resolution, test_runner: test_runner, gem_dir: gem_dir, test_gemfile: test_gemfile)
 
     minifier = RubyMinify::Minifier.new
     result = minifier.call(
@@ -149,7 +152,7 @@ class TestGemMinification < Minitest::Test
       File.write(minified_path, content)
 
       minified = run_gem_tests(test_files, tmpdir, test_runner: test_runner, gem_dir: gem_dir,
-                               replace_paths: resolution.require_paths)
+                               test_gemfile: test_gemfile, replace_paths: resolution.require_paths)
       minified_count = parse_test_count(minified[:stdout])
       assert minified_count,
         "#{gem_name} L#{level}: no test summary found (minified code likely crashed)\nstderr: #{minified[:stderr][0, 300]}"
@@ -161,11 +164,11 @@ class TestGemMinification < Minitest::Test
     end
   end
 
-  def baseline_failures_for(gem_name, test_files, resolution, test_runner: nil, gem_dir: nil)
+  def baseline_failures_for(gem_name, test_files, resolution, test_runner: nil, gem_dir: nil, test_gemfile: 'Gemfile')
     cache = self.class.baseline_cache
     return cache[gem_name] if cache.key?(gem_name)
 
-    baseline = run_gem_tests(test_files, resolution.require_paths.first, test_runner: test_runner, gem_dir: gem_dir)
+    baseline = run_gem_tests(test_files, resolution.require_paths.first, test_runner: test_runner, gem_dir: gem_dir, test_gemfile: test_gemfile)
     cache[gem_name] = parse_test_result(baseline[:stdout])
   end
 
@@ -173,7 +176,7 @@ class TestGemMinification < Minitest::Test
     @baseline_cache ||= {}
   end
 
-  def run_gem_tests(test_files, lib_dir, test_runner: nil, gem_dir: nil, replace_paths: [])
+  def run_gem_tests(test_files, lib_dir, test_runner: nil, gem_dir: nil, test_gemfile: 'Gemfile', replace_paths: [])
     test_files = Array(test_files)
     include_args = ["-I", lib_dir]
 
@@ -222,7 +225,7 @@ class TestGemMinification < Minitest::Test
     else
       File.dirname(test_files.first)
     end
-    gem_gemfile = gem_dir ? File.expand_path('Gemfile', gem_dir) : nil
+    gem_gemfile = gem_dir ? File.expand_path(test_gemfile, gem_dir) : nil
     pid = Bundler.with_unbundled_env do
       env = { 'BUNDLE_GEMFILE' => gem_gemfile }
       if gem_gemfile && File.exist?(gem_gemfile)

--- a/tests/test_gem_minification.rb
+++ b/tests/test_gem_minification.rb
@@ -1,15 +1,14 @@
 # frozen_string_literal: true
 
 require 'minitest/autorun'
-require 'tempfile'
 require 'fileutils'
 require 'rbconfig'
 require 'securerandom'
+require 'tempfile'
 require_relative '../lib/ruby_minify'
 
 # Test that minified gems pass their own test suites.
-# Excluded from default `rake test` — run with `rake test:gems`.
-# Requires BUNDLE_GEMFILE=Gemfile.gems_test so target gems are available.
+# Run with: BUNDLE_GEMFILE=Gemfile.gems_test bundle exec rake test:gems
 class TestGemMinification < Minitest::Test
   GEM_TESTS_DIR = File.expand_path('../gem_tests', __dir__)
 
@@ -17,312 +16,167 @@ class TestGemMinification < Minitest::Test
     sinatra: {
       gem_name: 'sinatra',
       test_gemfile: 'Gemfile.test',
-      test_files: %w[
-        sinatra/test/routing_test.rb
-        sinatra/test/helpers_test.rb
-        sinatra/test/settings_test.rb
-        sinatra/test/filter_test.rb
-        sinatra/test/request_test.rb
-        sinatra/test/response_test.rb
-        sinatra/test/result_test.rb
-        sinatra/test/base_test.rb
-        sinatra/test/delegator_test.rb
-        sinatra/test/streaming_test.rb
-        sinatra/test/middleware_test.rb
-        sinatra/test/sinatra_test.rb
-        sinatra/test/server_test.rb
-        sinatra/test/static_test.rb
-        sinatra/test/extensions_test.rb
-        sinatra/test/mapped_error_test.rb
-        sinatra/test/templates_test.rb
-        sinatra/test/route_added_hook_test.rb
-        sinatra/test/compile_test.rb
-        sinatra/test/host_authorization_test.rb
-        sinatra/test/indifferent_hash_test.rb
-        sinatra/test/rack_test.rb
-        sinatra/test/readme_test.rb
-        sinatra/test/erb_test.rb
-        sinatra/test/rdoc_test.rb
-        sinatra/test/liquid_test.rb
-        sinatra/test/encoding_test.rb
-        sinatra/test/asciidoctor_test.rb
-        sinatra/test/builder_test.rb
-        sinatra/test/haml_test.rb
-        sinatra/test/markaby_test.rb
-        sinatra/test/markdown_test.rb
-        sinatra/test/nokogiri_test.rb
-        sinatra/test/rabl_test.rb
-        sinatra/test/sass_test.rb
-        sinatra/test/scss_test.rb
-        sinatra/test/slim_test.rb
-        sinatra/test/yajl_test.rb
-      ],
-      min_level: 3,
-      max_level: 3,
+      test_patterns: ['sinatra/test/*_test.rb'],
+      exclude_patterns: ['sinatra/test/integration*_test.rb'],
+      levels: [3],
     },
     rubocop: {
       gem_name: 'rubocop',
       test_gemfile: 'Gemfile.test',
-      test_file_patterns: ['rubocop/spec/rubocop/**/*_spec.rb'],
-      exclude_test_patterns: %w[
-        rubocop/spec/rubocop/server/**/*_spec.rb
-        rubocop/spec/rubocop/cli/**/*_spec.rb
-      ],
-      exclude_test_files: %w[
-        rubocop/spec/rubocop/cops_documentation_generator_spec.rb
-        rubocop/spec/rubocop/runner_spec.rb
-        rubocop/spec/rubocop/cli_spec.rb
-        rubocop/spec/rubocop/lsp/server_spec.rb
-        rubocop/spec/rubocop/mcp/server_spec.rb
-        rubocop/spec/rubocop/runner_formatter_invocation_spec.rb
+      test_patterns: ['rubocop/spec/rubocop/**/*_spec.rb'],
+      exclude_patterns: [
+        'rubocop/spec/rubocop/{server,cli}/**/*_spec.rb',
+        'rubocop/spec/rubocop/cops_documentation_generator_spec.rb',
+        'rubocop/spec/rubocop/runner_spec.rb',
+        'rubocop/spec/rubocop/cli_spec.rb',
+        'rubocop/spec/rubocop/lsp/server_spec.rb',
+        'rubocop/spec/rubocop/mcp/server_spec.rb',
+        'rubocop/spec/rubocop/runner_formatter_invocation_spec.rb',
       ],
       test_runner: :rspec,
-      min_level: 3,
-      max_level: 3,
-    }
+      levels: [3],
+    },
   }.freeze
 
   GEMS.each do |gem_key, config|
-    min_level = config[:min_level] || 0
-    max_level = config[:max_level] || 5
-    (min_level..max_level).each do |level|
+    Array(config[:levels]).each do |level|
       define_method(:"test_#{gem_key}_level#{level}") do
-        gem_name = config[:gem_name]
-
-        begin
-          resolution = RubyMinify::GemResolver.new.call(gem_name)
-        rescue RubyMinify::Pipeline::GemNotFoundError
-          skip "#{gem_name} gem not available (use BUNDLE_GEMFILE=Gemfile.gems_test)"
-        end
-
-        test_files = resolve_test_files(config)
-        skip "no test files found for #{gem_name} (clone repos into gem_tests/)" if test_files.empty?
-        test_files.each { |f| skip "gem test not found: #{f}" unless File.exist?(f) }
+        resolution = resolve_gem(config[:gem_name])
+        test_files = collect_test_files(config)
+        skip "no test files for #{config[:gem_name]}" if test_files.empty?
 
         gem_dir = File.join(GEM_TESTS_DIR, gem_key.to_s)
-        test_gemfile = config[:test_gemfile] || 'Gemfile'
-        assert_minified_gem_passes(
-          resolution: resolution,
-          test_files: test_files,
-          level: level,
-          gem_name: gem_name,
-          test_runner: config[:test_runner],
-          gem_dir: gem_dir,
-          test_gemfile: test_gemfile
-        )
+        baseline_failures = run_baseline(config, test_files, gem_dir)
+
+        content, marker = minify_gem(config[:gem_name], resolution, level)
+        Dir.mktmpdir("minify_gem_test") do |tmpdir|
+          write_minified(tmpdir, resolution, content)
+
+          $stderr.puts "[#{config[:gem_name]}] Running minified L#{level} tests..."
+          stdout, = run_test_suite(test_files, config, gem_dir, lib_dir: tmpdir,
+                                   replace_paths: resolution.require_paths, marker: marker)
+          count = parse_test_count(stdout)
+          $stderr.puts "[#{config[:gem_name]}] Minified L#{level}: #{count || 'NO RESULT'} tests"
+
+          assert count, "#{config[:gem_name]} L#{level}: tests crashed\nstdout: #{stdout[0, 500]}"
+          assert count > 0, "#{config[:gem_name]} L#{level}: 0 tests ran"
+          new_failures = parse_failures(stdout) - baseline_failures
+          assert_equal [], new_failures,
+            "#{config[:gem_name]} L#{level}: #{new_failures.size} new failure(s)"
+        end
       end
     end
   end
 
   private
 
-  def resolve_test_files(config)
-    test_files = Array(config[:test_files]).map { |f| File.join(GEM_TESTS_DIR, f) }
-    if config[:test_file_patterns]
-      excludes = Array(config[:exclude_test_files]).map { |f| File.join(GEM_TESTS_DIR, f) }
-      Array(config[:exclude_test_patterns]).each do |pat|
-        excludes.concat(Dir.glob(File.join(GEM_TESTS_DIR, pat)))
-      end
-      config[:test_file_patterns].each do |pattern|
-        test_files.concat(Dir.glob(File.join(GEM_TESTS_DIR, pattern)) - excludes)
-      end
-      test_files.uniq!
-    end
-    test_files
+  def resolve_gem(gem_name)
+    RubyMinify::GemResolver.new.call(gem_name)
+  rescue RubyMinify::Pipeline::GemNotFoundError
+    skip "#{gem_name} gem not available (use BUNDLE_GEMFILE=Gemfile.gems_test)"
   end
 
-  def assert_minified_gem_passes(resolution:, test_files:, level:, gem_name:, test_runner: nil, gem_dir: nil, test_gemfile: 'Gemfile')
-    baseline_failures = baseline_failures_for(gem_name, test_files, resolution, test_runner: test_runner, gem_dir: gem_dir, test_gemfile: test_gemfile)
+  def collect_test_files(config)
+    files = Array(config[:test_patterns]).flat_map { |p| Dir.glob(File.join(GEM_TESTS_DIR, p)) }
+    excludes = Array(config[:exclude_patterns]).flat_map { |p| Dir.glob(File.join(GEM_TESTS_DIR, p)) }
+    (files - excludes).sort
+  end
 
-    minifier = RubyMinify::Minifier.new
-    result = minifier.call(
-      resolution.entry_path,
-      level: level,
+  def minify_gem(gem_name, resolution, level)
+    result = RubyMinify::Minifier.new.call(
+      resolution.entry_path, level: level,
       project_root: resolution.project_root,
-      gem_names: [gem_name],
-      gem_require_paths: resolution.require_paths
+      gem_names: [gem_name], gem_require_paths: resolution.require_paths
     )
-
-    content = result.aliases.empty? ? result.content : "#{result.content};#{result.aliases}"
     marker = "RUBY_MINIFY_MARKER_#{SecureRandom.hex(8)}"
-    content = "#{marker}=true;#{content}"
-
-    Dir.mktmpdir("minify_gem_test") do |tmpdir|
-      matching_root = resolution.require_paths.detect { |p| resolution.entry_path.start_with?("#{p}/") }
-      assert matching_root, "#{gem_name}: entry_path not under any require_path"
-      relative = resolution.entry_path.delete_prefix("#{matching_root}/")
-      minified_path = File.join(tmpdir, relative)
-      FileUtils.mkdir_p(File.dirname(minified_path))
-      File.write(minified_path, content)
-
-      $stderr.puts "[#{gem_name}] Running minified L#{level} tests..."
-      minified = run_gem_tests(test_files, tmpdir, test_runner: test_runner, gem_dir: gem_dir,
-                               test_gemfile: test_gemfile, replace_paths: resolution.require_paths,
-                               marker: marker)
-      minified_count = parse_test_count(minified[:stdout])
-      $stderr.puts "[#{gem_name}] Minified L#{level}: #{minified_count || 'NO RESULT'} tests"
-      assert minified_count,
-        "#{gem_name} L#{level}: no test summary found (minified code likely crashed)\nstderr: #{minified[:stderr][0, 300]}"
-      assert minified_count > 0, "#{gem_name} L#{level}: 0 tests ran\nstdout: #{minified[:stdout][0, 500]}\nstderr: #{minified[:stderr][0, 500]}"
-      minified_failures = parse_test_result(minified[:stdout])
-      new_failures = minified_failures - baseline_failures
-      assert new_failures.empty?,
-        "#{gem_name} L#{level}: #{new_failures.size} new failure(s) (not in baseline):\n#{new_failures.join("\n")}"
-    end
+    content = "#{marker}=true;#{result.content}"
+    content += ";#{result.aliases}" unless result.aliases.empty?
+    [content, marker]
   end
 
-  def baseline_failures_for(gem_name, test_files, resolution, test_runner: nil, gem_dir: nil, test_gemfile: 'Gemfile')
-    cache = self.class.baseline_cache
-    return cache[gem_name] if cache.key?(gem_name)
+  def write_minified(tmpdir, resolution, content)
+    root = resolution.require_paths.detect { |p| resolution.entry_path.start_with?("#{p}/") }
+    path = File.join(tmpdir, resolution.entry_path.delete_prefix("#{root}/"))
+    FileUtils.mkdir_p(File.dirname(path))
+    File.write(path, content)
+  end
+
+  # --- Baseline ---
+
+  @@baseline_cache = {} # rubocop:disable Style/ClassVars
+
+  def run_baseline(config, test_files, gem_dir)
+    gem_name = config[:gem_name]
+    return @@baseline_cache[gem_name] if @@baseline_cache.key?(gem_name)
 
     $stderr.puts "[#{gem_name}] Running baseline tests..."
-    baseline = run_gem_tests(test_files, nil, test_runner: test_runner, gem_dir: gem_dir, test_gemfile: test_gemfile)
-    $stderr.puts "[#{gem_name}] Baseline: #{parse_test_count(baseline[:stdout]) || 'NO RESULT'} tests"
-    $stderr.puts "[#{gem_name}] Baseline stderr: #{baseline[:stderr][0, 200]}" unless baseline[:stderr].empty?
-    cache[gem_name] = parse_test_result(baseline[:stdout])
+    stdout, stderr = run_test_suite(test_files, config, gem_dir)
+    $stderr.puts "[#{gem_name}] Baseline: #{parse_test_count(stdout) || 'NO RESULT'} tests"
+    $stderr.puts "[#{gem_name}] Baseline stderr: #{stderr[0, 200]}" unless stderr.empty?
+    @@baseline_cache[gem_name] = parse_failures(stdout)
   end
 
-  def self.baseline_cache
-    @baseline_cache ||= {}
+  # --- Subprocess ---
+
+  def run_test_suite(test_files, config, gem_dir, lib_dir: nil, replace_paths: [], marker: nil)
+    Tempfile.create(['runner', '.rb']) do |f|
+      write_runner_script(f, test_files, config, lib_dir: lib_dir,
+                          replace_paths: replace_paths, marker: marker)
+      f.close
+      gemfile = File.join(gem_dir, config[:test_gemfile] || 'Gemfile')
+      cmd = ['bundle', 'exec', RbConfig.ruby]
+      cmd += ['-I', lib_dir] if lib_dir
+      cmd << f.path
+      timeout = test_files.size > 100 ? 1200 : 300
+      capture_process({ 'BUNDLE_GEMFILE' => gemfile }, *cmd, chdir: gem_dir, timeout: timeout)
+    end
   end
 
-  def run_gem_tests(test_files, lib_dir, test_runner: nil, gem_dir: nil, test_gemfile: 'Gemfile', replace_paths: [], marker: nil)
-    test_files = Array(test_files)
-    include_args = lib_dir ? ["-I", lib_dir] : []
-
-    # Build a setup preamble that removes original gem paths and keeps lib_dir at front
-    setup_code = if replace_paths.any? && lib_dir
-      lines = replace_paths.map { |p| "$LOAD_PATH.delete(#{p.inspect})" }
-      lines << "$LOAD_PATH.unshift(#{lib_dir.inspect}) unless $LOAD_PATH[0] == #{lib_dir.inspect}"
-      if marker
-        lines << "at_exit { abort %q(MINIFY_MARKER_MISSING: loaded non-minified code!) unless defined?(#{marker}) }"
-      end
-      lines.join('; ')
+  def write_runner_script(f, test_files, config, lib_dir:, replace_paths:, marker:)
+    if lib_dir && replace_paths.any?
+      replace_paths.each { |p| f.puts "$LOAD_PATH.delete(#{p.inspect})" }
+      f.puts "$LOAD_PATH.unshift(#{lib_dir.inspect}) unless $LOAD_PATH[0] == #{lib_dir.inspect}"
+      f.puts "at_exit { abort 'MINIFY_MARKER_MISSING' unless defined?(#{marker}) }" if marker
     end
-
-    if test_runner == :rspec
-      args = build_rspec_args(test_files, lib_dir, include_args, setup_code: setup_code)
-    elsif test_files.size == 1
-      if setup_code
-        args = [*include_args, "-e", "#{setup_code}; load #{test_files.first.inspect}"]
-      else
-        args = [*include_args, test_files.first]
-      end
+    if config[:test_runner] == :rspec
+      spec_dir = test_files.first.then { |p| p[%r{.*/spec}] }
+      f.puts "$LOAD_PATH.unshift(#{spec_dir.inspect})" if spec_dir
+      f.puts 'require "rspec/core"'
+      f.puts "exit(RSpec::Core::Runner.run(#{test_files.inspect} + %w[--format progress --order defined --require spec_helper]))"
     else
-      runner = Tempfile.new(['gem_test_runner', '.rb'])
-      if setup_code
-        runner.write(<<~RUBY)
-          #{setup_code}
-          minified_lib = #{lib_dir.inspect}
-          original_unshift = $LOAD_PATH.method(:unshift)
-          $LOAD_PATH.define_singleton_method(:unshift) do |*args|
-            original_unshift.call(*args)
-            if $LOAD_PATH.index(minified_lib) != 0
-              $LOAD_PATH.delete(minified_lib)
-              original_unshift.call(minified_lib)
-            end
-            self
-          end
-          #{test_files.map { |f| "require #{f.inspect}" }.join("\n")}
-        RUBY
-      else
-        runner.write(test_files.map { |f| "require #{f.inspect}" }.join("\n"))
-      end
-      runner.flush
-      args = [*include_args, runner.path]
+      test_files.each { |tf| f.puts "require #{tf.inspect}" }
     end
-    stdout_file = Tempfile.new('gem_test_stdout')
-    stderr_file = Tempfile.new('gem_test_stderr')
-    stdout_file.close
-    stderr_file.close
-    work_dir = if gem_dir
-      gem_dir
-    elsif test_runner == :rspec
-      find_spec_dir(test_files.first) || File.dirname(test_files.first)
-    else
-      File.dirname(test_files.first)
-    end
-    gem_gemfile = gem_dir ? File.expand_path(test_gemfile, gem_dir) : nil
+    f.flush
+  end
+
+  def capture_process(env, *cmd, chdir:, timeout:)
+    out = Tempfile.new('stdout')
+    err = Tempfile.new('stderr')
     pid = Bundler.with_unbundled_env do
-      env = { 'BUNDLE_GEMFILE' => gem_gemfile }
-      if gem_gemfile && File.exist?(gem_gemfile)
-        cmd = ['bundle', 'exec', RbConfig.ruby, *args]
-      else
-        cmd = [RbConfig.ruby, *args]
-      end
-      spawn(
-        env,
-        *cmd,
-        chdir: work_dir,
-        out: [stdout_file.path, 'w'],
-        err: [stderr_file.path, 'w']
-      )
+      spawn(env, *cmd, chdir: chdir, out: [out.path, 'w'], err: [err.path, 'w'])
     end
-    timeout = test_files.size > 100 ? 1200 : test_files.size > 10 ? 300 : 120
-    waiter = Thread.new { Process.wait2(pid) }
-    if waiter.join(timeout)
-      { stdout: File.read(stdout_file.path), stderr: File.read(stderr_file.path), status: waiter.value[1] }
-    else
+    waiter = Thread.new { Process.waitpid(pid) }
+    unless waiter.join(timeout)
       Process.kill('TERM', pid)
-      waiter.join
-      { stdout: File.read(stdout_file.path), stderr: "TIMEOUT after #{timeout}s\n" + File.read(stderr_file.path), status: nil }
+      waiter.join(5)
     end
+    [File.read(out.path), File.read(err.path)]
   ensure
-    stdout_file&.close
-    stdout_file&.unlink
-    stderr_file&.close
-    stderr_file&.unlink
-    runner&.close!
-    @rspec_runner&.close!
-    @rspec_runner = nil
+    out&.close!
+    err&.close!
   end
 
-  def build_rspec_args(test_files, lib_dir, include_args, setup_code: nil)
-    spec_dir = find_spec_dir(test_files.first)
-    runner = Tempfile.new(['rspec_runner', '.rb'])
-    preamble = setup_code ? "#{setup_code}\n" : ""
-    runner.write(<<~RUBY)
-      #{preamble}$LOAD_PATH.unshift(#{spec_dir.inspect}) if #{!spec_dir.nil?}
-      require "rspec/core"
-      exit(RSpec::Core::Runner.run(#{test_files.inspect} + ["--format", "progress", "--order", "defined", "--require", "spec_helper"]))
-    RUBY
-    runner.flush
-    @rspec_runner = runner
-    [*include_args, runner.path]
-  end
-
-  def find_spec_dir(test_file)
-    dir = File.dirname(test_file)
-    until dir == '/' || dir == '.'
-      return dir if File.basename(dir) == 'spec'
-      dir = File.dirname(dir)
-    end
-    nil
-  end
+  # --- Parsing ---
 
   def parse_test_count(output)
-    if output =~ /(\d+) (?:runs?|tests?),/
-      $1.to_i
-    elsif output =~ /(\d+) examples?,/
-      $1.to_i
-    end
+    $1.to_i if output =~ /(\d+) (?:runs?|tests?|examples?),/
   end
 
-  def parse_test_result(output)
+  def parse_failures(output)
     failures = []
-
-    output.scan(/^(?:Failure|Error): (\S+)\((\S+)\)/) do |test_name, klass|
-      failures << "#{klass}##{test_name}"
-    end
-
-    output.scan(/^\s+\d+\) (?:Failure|Error):\n(\S+#\S+)/) do |match|
-      failures << match[0]
-    end
-
-    output.scan(/^rspec (\S+:\d+)/) do |match|
-      failures << match[0]
-    end
-
+    output.scan(/^(?:Failure|Error): (\S+)\((\S+)\)/) { |n, k| failures << "#{k}##{n}" }
+    output.scan(/^\s+\d+\) (?:Failure|Error):\n(\S+#\S+)/) { |m| failures << m[0] }
+    output.scan(/^rspec (\S+:\d+)/) { |m| failures << m[0] }
     failures.sort.uniq
   end
 end

--- a/tests/test_gem_minification.rb
+++ b/tests/test_gem_minification.rb
@@ -209,8 +209,12 @@ class TestGemMinification < Minitest::Test
     else
       File.dirname(test_files.first)
     end
+    gem_gemfile = gem_dir ? File.join(gem_dir, 'Gemfile') : nil
     pid = Bundler.with_unbundled_env do
+      env = {}
+      env['BUNDLE_GEMFILE'] = gem_gemfile if gem_gemfile && File.exist?(gem_gemfile)
       spawn(
+        env,
         RbConfig.ruby, *args,
         chdir: work_dir,
         out: [stdout_file.path, 'w'],

--- a/tests/test_gem_minification.rb
+++ b/tests/test_gem_minification.rb
@@ -59,27 +59,26 @@ class TestGemMinification < Minitest::Test
       min_level: 3,
       max_level: 3,
     },
-    # rubocop: disabled — preamble references unresolved top-level constants (e.g. E=NodePattern).
-    # See: https://github.com/ahogappa/ruby-minify/issues/18
-    # rubocop: {
-    #   gem_name: 'rubocop',
-    #   test_file_patterns: ['rubocop/spec/rubocop/**/*_spec.rb'],
-    #   exclude_test_patterns: %w[
-    #     rubocop/spec/rubocop/server/**/*_spec.rb
-    #     rubocop/spec/rubocop/cli/**/*_spec.rb
-    #   ],
-    #   exclude_test_files: %w[
-    #     rubocop/spec/rubocop/cops_documentation_generator_spec.rb
-    #     rubocop/spec/rubocop/runner_spec.rb
-    #     rubocop/spec/rubocop/cli_spec.rb
-    #     rubocop/spec/rubocop/lsp/server_spec.rb
-    #     rubocop/spec/rubocop/mcp/server_spec.rb
-    #     rubocop/spec/rubocop/runner_formatter_invocation_spec.rb
-    #   ],
-    #   test_runner: :rspec,
-    #   min_level: 3,
-    #   max_level: 3,
-    # }
+    rubocop: {
+      gem_name: 'rubocop',
+      test_gemfile: 'Gemfile.test',
+      test_file_patterns: ['rubocop/spec/rubocop/**/*_spec.rb'],
+      exclude_test_patterns: %w[
+        rubocop/spec/rubocop/server/**/*_spec.rb
+        rubocop/spec/rubocop/cli/**/*_spec.rb
+      ],
+      exclude_test_files: %w[
+        rubocop/spec/rubocop/cops_documentation_generator_spec.rb
+        rubocop/spec/rubocop/runner_spec.rb
+        rubocop/spec/rubocop/cli_spec.rb
+        rubocop/spec/rubocop/lsp/server_spec.rb
+        rubocop/spec/rubocop/mcp/server_spec.rb
+        rubocop/spec/rubocop/runner_formatter_invocation_spec.rb
+      ],
+      test_runner: :rspec,
+      min_level: 3,
+      max_level: 3,
+    }
   }.freeze
 
   GEMS.each do |gem_key, config|

--- a/tests/test_gem_minification.rb
+++ b/tests/test_gem_minification.rb
@@ -59,25 +59,27 @@ class TestGemMinification < Minitest::Test
       min_level: 3,
       max_level: 3,
     },
-    rubocop: {
-      gem_name: 'rubocop',
-      test_file_patterns: ['rubocop/spec/rubocop/**/*_spec.rb'],
-      exclude_test_patterns: %w[
-        rubocop/spec/rubocop/server/**/*_spec.rb
-        rubocop/spec/rubocop/cli/**/*_spec.rb
-      ],
-      exclude_test_files: %w[
-        rubocop/spec/rubocop/cops_documentation_generator_spec.rb
-        rubocop/spec/rubocop/runner_spec.rb
-        rubocop/spec/rubocop/cli_spec.rb
-        rubocop/spec/rubocop/lsp/server_spec.rb
-        rubocop/spec/rubocop/mcp/server_spec.rb
-        rubocop/spec/rubocop/runner_formatter_invocation_spec.rb
-      ],
-      test_runner: :rspec,
-      min_level: 3,
-      max_level: 3,
-    }
+    # rubocop: disabled — L3 minification produces syntax errors (duplicated argument names).
+    # See: https://github.com/ahogappa/ruby-minify/issues/TODO
+    # rubocop: {
+    #   gem_name: 'rubocop',
+    #   test_file_patterns: ['rubocop/spec/rubocop/**/*_spec.rb'],
+    #   exclude_test_patterns: %w[
+    #     rubocop/spec/rubocop/server/**/*_spec.rb
+    #     rubocop/spec/rubocop/cli/**/*_spec.rb
+    #   ],
+    #   exclude_test_files: %w[
+    #     rubocop/spec/rubocop/cops_documentation_generator_spec.rb
+    #     rubocop/spec/rubocop/runner_spec.rb
+    #     rubocop/spec/rubocop/cli_spec.rb
+    #     rubocop/spec/rubocop/lsp/server_spec.rb
+    #     rubocop/spec/rubocop/mcp/server_spec.rb
+    #     rubocop/spec/rubocop/runner_formatter_invocation_spec.rb
+    #   ],
+    #   test_runner: :rspec,
+    #   min_level: 3,
+    #   max_level: 3,
+    # }
   }.freeze
 
   GEMS.each do |gem_key, config|

--- a/tests/test_gem_minification.rb
+++ b/tests/test_gem_minification.rb
@@ -212,10 +212,15 @@ class TestGemMinification < Minitest::Test
     gem_gemfile = gem_dir ? File.join(gem_dir, 'Gemfile') : nil
     pid = Bundler.with_unbundled_env do
       env = {}
-      env['BUNDLE_GEMFILE'] = gem_gemfile if gem_gemfile && File.exist?(gem_gemfile)
+      if gem_gemfile && File.exist?(gem_gemfile)
+        env['BUNDLE_GEMFILE'] = gem_gemfile
+        cmd = ['bundle', 'exec', RbConfig.ruby, *args]
+      else
+        cmd = [RbConfig.ruby, *args]
+      end
       spawn(
         env,
-        RbConfig.ruby, *args,
+        *cmd,
         chdir: work_dir,
         out: [stdout_file.path, 'w'],
         err: [stderr_file.path, 'w']

--- a/tests/test_gem_minification.rb
+++ b/tests/test_gem_minification.rb
@@ -251,7 +251,7 @@ class TestGemMinification < Minitest::Test
         err: [stderr_file.path, 'w']
       )
     end
-    timeout = test_files.size > 10 ? 180 : 120
+    timeout = test_files.size > 100 ? 1200 : test_files.size > 10 ? 300 : 120
     waiter = Thread.new { Process.wait2(pid) }
     if waiter.join(timeout)
       { stdout: File.read(stdout_file.path), stderr: File.read(stderr_file.path), status: waiter.value[1] }

--- a/tests/test_gem_minification.rb
+++ b/tests/test_gem_minification.rb
@@ -101,7 +101,7 @@ class TestGemMinification < Minitest::Test
           resolution: resolution,
           test_files: test_files,
           level: level,
-          gem_name: gem_key,
+          gem_name: gem_name,
           test_runner: config[:test_runner],
           gem_dir: gem_dir
         )
@@ -134,14 +134,16 @@ class TestGemMinification < Minitest::Test
       resolution.entry_path,
       level: level,
       project_root: resolution.project_root,
-      gem_names: [gem_name.to_s],
+      gem_names: [gem_name],
       gem_require_paths: resolution.require_paths
     )
 
     content = result.aliases.empty? ? result.content : "#{result.content};#{result.aliases}"
 
     Dir.mktmpdir("minify_gem_test") do |tmpdir|
-      relative = resolution.entry_path.delete_prefix("#{resolution.require_paths.first}/")
+      matching_root = resolution.require_paths.detect { |p| resolution.entry_path.start_with?("#{p}/") }
+      assert matching_root, "#{gem_name}: entry_path not under any require_path"
+      relative = resolution.entry_path.delete_prefix("#{matching_root}/")
       minified_path = File.join(tmpdir, relative)
       FileUtils.mkdir_p(File.dirname(minified_path))
       File.write(minified_path, content)


### PR DESCRIPTION
## Summary

- Add `Gemfile.gems_test` with `path:` references to cloned sinatra/rubocop repos
- Simplify CI `external-gems` job: single `bundle install` with `BUNDLE_GEMFILE=Gemfile.gems_test`
- Rewrite `test_gem_minification.rb` to use `GemResolver` for gem resolution

## What changed

**Before**: Manual per-gem config with `source`, `lib_name`, `extra_includes`, `copy_files`, `file_depth`, `project_files` — 87 lines of GEMS config, complex `assert_minified_gem_passes` with file copying and stub generation.

**After**: Minimal config with just `gem_name`, test files, and levels — GemResolver handles entry path, project root, and require path resolution automatically. Net **-51 lines**.

## Test plan

- [x] `bundle exec rake test` — 818 tests pass (gem tests skip cleanly when repos not cloned)
- [ ] CI `external-gems` job with `BUNDLE_GEMFILE=Gemfile.gems_test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a test-specific gemfile and updated CI to install dependencies once in parallel, ensuring per-repo installs use the intended gemfile.
* **Tests**
  * Refactored integration tests: improved gem resolution with explicit skip guidance when gems are unavailable, centralized test-file discovery, simplified temp output/layout handling, and streamlined test invocation to conditionally use the test gemfile for more reliable runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->