### PR TITLE
Fix preamble using unqualified constant names for external gems

### DIFF
--- a/lib/ruby_minify/analysis/constant/collection.rb
+++ b/lib/ruby_minify/analysis/constant/collection.rb
@@ -187,10 +187,11 @@ module RubyMinify
       resolved_cpath = resolve_constant_read_cpath(node)
       is_user_defined = (full_path && @constant_mapping.user_defined_path?(full_path)) ||
                         (resolved_cpath && @constant_mapping.user_defined_path?(resolved_cpath))
-      if full_path && !is_user_defined
-        next if full_path.size < 2
-        next if @constant_mapping.has_user_defined_prefix?(full_path)
-        prefix = full_path[0...-1]
+      effective_path = resolved_cpath || full_path
+      if effective_path && !is_user_defined
+        next if effective_path.size < 2
+        next if full_path && @constant_mapping.has_user_defined_prefix?(full_path)
+        prefix = effective_path[0...-1]
         prefix_counts[prefix] += 1
       end
     end

--- a/lib/ruby_minify/pipeline/analyzer.rb
+++ b/lib/ruby_minify/pipeline/analyzer.rb
@@ -385,8 +385,9 @@ module RubyMinify
           case node
           when TypeProf::Core::AST::ConstantReadNode
             key = AstUtils.location_key(node)
-            @const_resolution_map[key] = resolve_constant_read_cpath(node)
-            @const_full_path_map[key] = build_constant_path(node)
+            resolved = resolve_constant_read_cpath(node)
+            @const_resolution_map[key] = resolved
+            @const_full_path_map[key] = resolved || build_constant_path(node)
           when TypeProf::Core::AST::ConstantWriteNode
             @const_write_cpath_map[AstUtils.location_key(node)] = normalize_const_write_cpath(node)
           when TypeProf::Core::AST::ClassNode

--- a/lib/ruby_minify/pipeline/data_types.rb
+++ b/lib/ruby_minify/pipeline/data_types.rb
@@ -102,7 +102,7 @@ module RubyMinify
       :block_param_names_map,      # Hash<location_key, Hash<Symbol, String>>: pre-computed block param mangled names
       :syntax_data,                # Hash<[line,col], Hash>: Prism-derived syntax metadata
       :const_resolution_map,       # Hash<location_key, Array>: resolved constant cpaths
-      :const_full_path_map,        # Hash<location_key, Array>: syntactic constant paths
+      :const_full_path_map,        # Hash<location_key, Array>: resolved constant paths (fallback: syntactic)
       :const_write_cpath_map,      # Hash<location_key, Array>: normalized write cpaths
       :class_cpath_map,            # Hash<location_key, Array>: class/module cpaths
       :superclass_resolution_map,  # Hash<location_key, Array>: resolved superclass paths

--- a/tests/ruby_minify/pipeline/test_constant_aliaser.rb
+++ b/tests/ruby_minify/pipeline/test_constant_aliaser.rb
@@ -47,6 +47,35 @@ class TestConstantAliaserPipeline < Minitest::Test
                  result.code
   end
 
+  def test_external_prefix_uses_resolved_path_for_unqualified_refs
+    code = <<~RUBY
+      module Outer
+        module Other
+          class Worker
+            def run
+              Inner::Leaf.new
+              Inner::Leaf.new
+              Inner::Leaf.new
+            end
+          end
+        end
+      end
+    RUBY
+    rbs_files = { "outer.rbs" => <<~RBS }
+      module Outer
+        module Inner
+          class Leaf
+            def initialize: () -> void
+          end
+        end
+      end
+    RBS
+    result = minify_at_level(code, 2, verify_output: false, rbs_files: rbs_files)
+    assert_equal 'A=Outer::Inner', result.preamble
+    assert_equal 'module Outer;module Other;class Worker;def run =(A::Leaf.new;A::Leaf.new;A::Leaf.new);end;end;end',
+                 result.code
+  end
+
   def test_constant_path_write_and_superclass_renaming
     code = <<~RUBY
       module Framework

--- a/tests/test_gem_minification.rb
+++ b/tests/test_gem_minification.rb
@@ -334,17 +334,4 @@ class TestGemMinification < Minitest::Test
     failures.sort.uniq
   end
 
-  public
-
-  def test_rubocop_preamble_uses_qualified_constants
-    resolution = RubyMinify::GemResolver.new.call("rubocop")
-    result = RubyMinify::Minifier.new.call(resolution.entry_path, level: 3,
-      project_root: resolution.project_root,
-      gem_names: ["rubocop"],
-      gem_require_paths: resolution.require_paths)
-    decls = result.preamble.split(';').map { |d| d.split('=', 2) }
-    rhs_map = decls.to_h { |lhs, rhs| [rhs, lhs] }
-    assert_equal 'B', rhs_map['RuboCop::NodePattern']
-    assert_equal 'K', rhs_map['RuboCop::Formatter']
-  end
 end

--- a/tests/test_gem_minification.rb
+++ b/tests/test_gem_minification.rb
@@ -333,5 +333,4 @@ class TestGemMinification < Minitest::Test
 
     failures.sort.uniq
   end
-
 end

--- a/tests/test_gem_minification.rb
+++ b/tests/test_gem_minification.rb
@@ -333,4 +333,18 @@ class TestGemMinification < Minitest::Test
 
     failures.sort.uniq
   end
+
+  public
+
+  def test_rubocop_preamble_uses_qualified_constants
+    resolution = RubyMinify::GemResolver.new.call("rubocop")
+    result = RubyMinify::Minifier.new.call(resolution.entry_path, level: 3,
+      project_root: resolution.project_root,
+      gem_names: ["rubocop"],
+      gem_require_paths: resolution.require_paths)
+    decls = result.preamble.split(';').map { |d| d.split('=', 2) }
+    rhs_map = decls.to_h { |lhs, rhs| [rhs, lhs] }
+    assert_equal 'B', rhs_map['RuboCop::NodePattern']
+    assert_equal 'K', rhs_map['RuboCop::Formatter']
+  end
 end


### PR DESCRIPTION
## Summary

- Use TypeProf's resolved constant paths (`resolve_constant_read_cpath`) instead of syntactic paths (`build_constant_path`) when building external prefix declarations
- Before: `E=NodePattern` (NameError at top level)
- After: `B=RuboCop::NodePattern` (fully qualified, works at top level)

Changes in two files:
- `collection.rb`: `collect_external_references` uses resolved path for prefix building
- `analyzer.rb`: `const_full_path_map` stores resolved path so patching finds the correct prefix

Closes #20

## Test plan

- [x] Added `test_rubocop_preamble_uses_qualified_constants` verifying `NodePattern` and `Formatter` are fully qualified
- [x] Full test suite passes (821 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced robustness of constant resolution when handling unresolved constants
  * Improved handling of external constant references in nested namespaces

* **Tests**
  * Added test coverage for unqualified constant references with resolved paths
<!-- end of auto-generated comment: release notes by coderabbit.ai -->