### PR TITLE
fix: skip user-defined alias prefix in external preamble declarations

### DIFF
--- a/lib/ruby_minify/analysis/constant/collection.rb
+++ b/lib/ruby_minify/analysis/constant/collection.rb
@@ -192,6 +192,7 @@ module RubyMinify
         next if effective_path.size < 2
         next if full_path && @constant_mapping.has_user_defined_prefix?(full_path)
         prefix = effective_path[0...-1]
+        next if @constant_mapping.user_defined_path?(prefix)
         prefix_counts[prefix] += 1
       end
     end

--- a/tests/ruby_minify/pipeline/test_constant_aliaser.rb
+++ b/tests/ruby_minify/pipeline/test_constant_aliaser.rb
@@ -142,8 +142,7 @@ class TestConstantAliaserPipeline < Minitest::Test
       end
     RUBY
     result = minify_at_level(code, 3, verify_output: false)
-    preamble_rhs = result.preamble.split(';').map { |d| d.split('=', 2).last }
-    assert_equal true, preamble_rhs.none? { |rhs| rhs.include?('AliasedInner') }
+    assert_equal '', result.preamble
   end
 
   def test_singleton_class_constant_not_renamed

--- a/tests/ruby_minify/pipeline/test_constant_aliaser.rb
+++ b/tests/ruby_minify/pipeline/test_constant_aliaser.rb
@@ -122,6 +122,30 @@ class TestConstantAliaserPipeline < Minitest::Test
     assert_equal 'Formatter::SEPARATOR=Formatter::A', result.aliases
   end
 
+  def test_aliased_constant_prefix_not_in_preamble
+    code = <<~RUBY
+      module Outer
+        module Inner
+          class Leaf
+          end
+        end
+        AliasedInner = Inner
+        module Consumer
+          class Worker
+            def run
+              AliasedInner::Leaf.new
+              AliasedInner::Leaf.new
+              AliasedInner::Leaf.new
+            end
+          end
+        end
+      end
+    RUBY
+    result = minify_at_level(code, 3, verify_output: false)
+    preamble_rhs = result.preamble.split(';').map { |d| d.split('=', 2).last }
+    assert_equal true, preamble_rhs.none? { |rhs| rhs.include?('AliasedInner') }
+  end
+
   def test_singleton_class_constant_not_renamed
     # Constants defined in `class << self` live on the metaclass —
     # they cannot be accessed as `Foo::X` from outside, so alias


### PR DESCRIPTION
## Summary

- Fix `collect_external_references` to check `user_defined_path?` on the resolved `effective_path` prefix, preventing user-defined constant aliases from being incorrectly added to the external preamble
- Add regression test for aliased constant prefix (`AliasedInner = Inner` pattern)

Closes #24

## Test plan

- [x] New test `test_aliased_constant_prefix_not_in_preamble` passes
- [x] All existing constant aliaser and collection tests pass
- [ ] Verify with reproducer code from the issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of aliased constant prefixes during minification to ensure they are not incorrectly included in the generated output.

* **Tests**
  * Added test coverage verifying proper treatment of aliased constant prefixes in minification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->