### PR TITLE
fix: resolve bare require-style autoload paths via $LOAD_PATH

### DIFF
--- a/lib/ruby_minify/pipeline/file_collector.rb
+++ b/lib/ruby_minify/pipeline/file_collector.rb
@@ -229,6 +229,17 @@ module RubyMinify
               in_method: in_method,
               resolved_path: resolve_relative_path(path, file_path)
             }
+          elsif (resolved = resolve_bare_require(path))
+            nodes << {
+              type: :autoload,
+              path: path,
+              line: node.location.start_line,
+              start_offset: node.location.start_offset,
+              length: node.location.length,
+              in_class: in_class,
+              in_method: in_method,
+              resolved_path: resolved
+            }
           end
         else
           return if in_method

--- a/tests/fixtures/multi_file/autoload_bare_require_test/main.rb
+++ b/tests/fixtures/multi_file/autoload_bare_require_test/main.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module MyLib
+  autoload :Formatter, "my_lib/formatter"
+
+  class Runner
+    def run
+      Formatter.new.format("hello")
+    end
+  end
+end

--- a/tests/fixtures/multi_file/autoload_bare_require_test/my_lib/formatter.rb
+++ b/tests/fixtures/multi_file/autoload_bare_require_test/my_lib/formatter.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module MyLib
+  class Formatter
+    def format(text)
+      text.upcase
+    end
+  end
+end

--- a/tests/ruby_minify/pipeline/test_concatenator.rb
+++ b/tests/ruby_minify/pipeline/test_concatenator.rb
@@ -201,12 +201,13 @@ class TestConcatenator < Minitest::Test
         content: main_content,
         deps: [], in_class_deps: ["/my_lib/formatter.rb"],
         require_nodes: [{ type: :autoload, path: "my_lib/formatter",
-                          line: 2, start_offset: 14, length: 43, in_class: true,
+                          line: 2, start_offset: 15, length: 39, in_class: true,
                           resolved_path: "/my_lib/formatter.rb" }]
       }
     )
     result = @concatenator.call(graph)
-    assert_equal false, result.content.include?("autoload")
+    expected = "module MyLib\n  class Formatter\n    def format(text)\n      text.upcase\n    end\n  end\n\n  class Runner\n    def run\n      Formatter.new.format(\"hello\")\n    end\n  end\nend"
+    assert_equal expected, result.content
   end
 
   def test_autoload_top_level_removed
@@ -218,13 +219,12 @@ class TestConcatenator < Minitest::Test
         content: main_content,
         deps: ["/formatter.rb"],
         require_nodes: [{ type: :autoload, path: "formatter",
-                          line: 1, start_offset: 0, length: 31,
+                          line: 1, start_offset: 0, length: 32,
                           resolved_path: "/formatter.rb" }]
       }
     )
     result = @concatenator.call(graph)
-    assert_equal false, result.content.include?("autoload")
-    assert_equal true, result.content.include?("puts 1")
+    assert_equal "class Formatter; end\nputs 1", result.content
   end
 
   private

--- a/tests/ruby_minify/pipeline/test_concatenator.rb
+++ b/tests/ruby_minify/pipeline/test_concatenator.rb
@@ -192,6 +192,41 @@ class TestConcatenator < Minitest::Test
     assert_equal({ "/a.rbs" => "class A; end" }, result.rbs_files)
   end
 
+  def test_autoload_declaration_removed_when_dependency_inlined
+    formatter_content = "module MyLib\n  class Formatter\n    def format(text)\n      text.upcase\n    end\n  end\nend"
+    main_content = "module MyLib\n  autoload :Formatter, \"my_lib/formatter\"\n\n  class Runner\n    def run\n      Formatter.new.format(\"hello\")\n    end\n  end\nend"
+    graph = build_graph(
+      "/my_lib/formatter.rb" => { content: formatter_content, deps: [] },
+      "/main.rb" => {
+        content: main_content,
+        deps: [], in_class_deps: ["/my_lib/formatter.rb"],
+        require_nodes: [{ type: :autoload, path: "my_lib/formatter",
+                          line: 2, start_offset: 14, length: 43, in_class: true,
+                          resolved_path: "/my_lib/formatter.rb" }]
+      }
+    )
+    result = @concatenator.call(graph)
+    assert_equal false, result.content.include?("autoload")
+  end
+
+  def test_autoload_top_level_removed
+    formatter_content = "class Formatter; end"
+    main_content = "autoload :Formatter, \"formatter\"\nputs 1"
+    graph = build_graph(
+      "/formatter.rb" => { content: formatter_content, deps: [] },
+      "/main.rb" => {
+        content: main_content,
+        deps: ["/formatter.rb"],
+        require_nodes: [{ type: :autoload, path: "formatter",
+                          line: 1, start_offset: 0, length: 31,
+                          resolved_path: "/formatter.rb" }]
+      }
+    )
+    result = @concatenator.call(graph)
+    assert_equal false, result.content.include?("autoload")
+    assert_equal true, result.content.include?("puts 1")
+  end
+
   private
 
   def build_graph(files)

--- a/tests/ruby_minify/pipeline/test_file_collector.rb
+++ b/tests/ruby_minify/pipeline/test_file_collector.rb
@@ -166,30 +166,19 @@ class TestFileCollector < Minitest::Test
   end
 
   def test_autoload_with_bare_require_path_collects_dependency
-    Dir.mktmpdir do |tmpdir|
-      lib_dir = File.join(tmpdir, 'lib')
-      sub_dir = File.join(lib_dir, 'my_lib')
-      Dir.mkdir(lib_dir)
-      Dir.mkdir(sub_dir)
-      File.write(File.join(tmpdir, 'Gemfile'), '')
-      File.write(File.join(sub_dir, 'formatter.rb'), 'class Formatter; end')
-      File.write(File.join(lib_dir, 'entry.rb'), <<~RUBY)
-        module MyLib
-          autoload :Formatter, "my_lib/formatter"
-        end
-      RUBY
+    fixture_dir = File.join(@fixtures_dir, 'autoload_bare_require_test')
+    entry_path = File.join(fixture_dir, 'main.rb')
+    formatter_path = File.join(fixture_dir, 'my_lib', 'formatter.rb')
 
-      $LOAD_PATH.unshift(lib_dir)
-      begin
-        graph = @collector.call(File.join(lib_dir, 'entry.rb'), project_root: tmpdir)
-        formatter_path = File.join(sub_dir, 'formatter.rb')
-        entry = graph[File.join(lib_dir, 'entry.rb')]
-        autoload_nodes = entry.require_nodes.select { |n| n[:type] == :autoload }
-        assert_equal 1, autoload_nodes.size
-        assert_equal formatter_path, autoload_nodes.first[:resolved_path]
-      ensure
-        $LOAD_PATH.delete(lib_dir)
-      end
+    $LOAD_PATH.unshift(fixture_dir)
+    begin
+      graph = @collector.call(entry_path, project_root: fixture_dir)
+      entry = graph[entry_path]
+      autoload_nodes = entry.require_nodes.select { |n| n[:type] == :autoload }
+      assert_equal 1, autoload_nodes.size
+      assert_equal formatter_path, autoload_nodes.first[:resolved_path]
+    ensure
+      $LOAD_PATH.delete(fixture_dir)
     end
   end
 

--- a/tests/ruby_minify/pipeline/test_file_collector.rb
+++ b/tests/ruby_minify/pipeline/test_file_collector.rb
@@ -165,6 +165,34 @@ class TestFileCollector < Minitest::Test
     assert graph[helper_path], "autoloaded file should be collected"
   end
 
+  def test_autoload_with_bare_require_path_collects_dependency
+    Dir.mktmpdir do |tmpdir|
+      lib_dir = File.join(tmpdir, 'lib')
+      sub_dir = File.join(lib_dir, 'my_lib')
+      Dir.mkdir(lib_dir)
+      Dir.mkdir(sub_dir)
+      File.write(File.join(tmpdir, 'Gemfile'), '')
+      File.write(File.join(sub_dir, 'formatter.rb'), 'class Formatter; end')
+      File.write(File.join(lib_dir, 'entry.rb'), <<~RUBY)
+        module MyLib
+          autoload :Formatter, "my_lib/formatter"
+        end
+      RUBY
+
+      $LOAD_PATH.unshift(lib_dir)
+      begin
+        graph = @collector.call(File.join(lib_dir, 'entry.rb'), project_root: tmpdir)
+        formatter_path = File.join(sub_dir, 'formatter.rb')
+        entry = graph[File.join(lib_dir, 'entry.rb')]
+        autoload_nodes = entry.require_nodes.select { |n| n[:type] == :autoload }
+        assert_equal 1, autoload_nodes.size
+        assert_equal formatter_path, autoload_nodes.first[:resolved_path]
+      ensure
+        $LOAD_PATH.delete(lib_dir)
+      end
+    end
+  end
+
   def test_dynamic_autoload_at_top_level_raises
     Dir.mktmpdir do |tmpdir|
       File.write(File.join(tmpdir, 'entry.rb'), <<~RUBY)


### PR DESCRIPTION
## Summary

- Fix `handle_autoload` in `FileCollector` to resolve bare require-style paths (e.g., `"my_lib/formatter"`) via `$LOAD_PATH`, matching the existing behavior in `handle_require`
- Previously, autoload declarations with paths containing `/` but not starting with `./` or `../` were silently ignored, leaving them in minified output and causing `LoadError` at runtime

## Root Cause

`handle_autoload` only resolved relative paths (`./`, `../`) and simple names (no `/`). Paths like `"my_lib/formatter"` fell through without creating a require node, so the concatenator never removed them.

## Test plan

- [x] Added unit test for `FileCollector` verifying bare autoload path resolution
- [x] Added unit tests for `Concatenator` verifying autoload removal (in-class inline and top-level removal)
- [x] All 825 existing tests pass with no regressions
- [x] Coverage: 98.73%

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced autoload handling to properly resolve bare require-style paths (e.g., `"my_lib/formatter"`), enabling accurate dependency detection in minification pipelines and improving analysis of Ruby projects using autoload declarations with string literals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->