### PR TITLE
fix: rename references to aliased constants in constant aliaser

### DIFF
--- a/lib/ruby_minify/pipeline/constant_aliaser.rb
+++ b/lib/ruby_minify/pipeline/constant_aliaser.rb
@@ -73,6 +73,10 @@ module RubyMinify
           end
           loc = node.location
           patches << { start: loc.start_offset, end: loc.end_offset, replacement: short }
+        elsif node.is_a?(Prism::ConstantPathNode) && resolved_cpath &&
+              (short = build_renamed_via_user_prefix(node, analysis))
+          loc = node.location
+          patches << { start: loc.start_offset, end: loc.end_offset, replacement: short }
         elsif prefix_alias
           short = "#{prefix_alias}::#{node.name}"
           loc = node.location
@@ -156,6 +160,27 @@ module RubyMinify
           mark_constant_children(node.parent) if node.parent
         when Prism::ConstantReadNode
           @class_module_cpath_offsets << node.location.start_offset
+        end
+      end
+
+      def build_renamed_via_user_prefix(node, analysis)
+        parent_node = node.parent
+        return nil unless parent_node
+
+        parent_key = prism_location_key(parent_node)
+        parent_resolved = analysis.const_resolution_map[parent_key]
+        return nil unless parent_resolved
+
+        if analysis.constant_mapping.user_defined_path?(parent_resolved)
+          parent_short = if parent_node.is_a?(Prism::ConstantReadNode)
+            analysis.constant_mapping.short_name_for_path(parent_resolved) || parent_node.name.to_s
+          else
+            get_short_cpath(parent_resolved, analysis)
+          end
+          "#{parent_short}::#{node.name}"
+        elsif parent_node.is_a?(Prism::ConstantPathNode)
+          parent_renamed = build_renamed_via_user_prefix(parent_node, analysis)
+          parent_renamed ? "#{parent_renamed}::#{node.name}" : nil
         end
       end
 

--- a/tests/ruby_minify/pipeline/test_constant_aliaser.rb
+++ b/tests/ruby_minify/pipeline/test_constant_aliaser.rb
@@ -145,6 +145,36 @@ class TestConstantAliaserPipeline < Minitest::Test
     assert_equal '', result.preamble
   end
 
+  def test_aliased_constant_references_are_renamed
+    code = <<~RUBY
+      module Outer
+        module External
+          module Macros
+            def helper; end
+          end
+        end
+        AliasConst = External
+        class Base
+          extend AliasConst::Macros
+        end
+        class Worker < Base
+          extend AliasConst::Macros
+        end
+        class Runner < Base
+          extend AliasConst::Macros
+        end
+      end
+    RUBY
+    result = minify_at_level(code, 2, verify_output: false)
+    assert_equal 'module Outer;module External;module Macros;def helper;end;end;end;' \
+                 'A=External;class Base;extend A::Macros;end;' \
+                 'class Worker<Outer::Base;extend A::Macros;end;' \
+                 'class Runner<Outer::Base;extend A::Macros;end;end',
+                 result.code
+    assert_equal 'Outer::AliasConst=Outer::A', result.aliases
+    assert_equal '', result.preamble
+  end
+
   def test_singleton_class_constant_not_renamed
     # Constants defined in `class << self` live on the metaclass —
     # they cannot be accessed as `Foo::X` from outside, so alias


### PR DESCRIPTION
## Summary

- Add `build_renamed_via_user_prefix` to walk the Prism parent chain and rename references through user-defined alias constants (e.g., `AliasConst::Macros` → `B::Macros`)

Builds on #26 which prevents user-defined alias prefixes from being registered as external preamble declarations.

Closes #23

## Test plan

- [x] New test `test_aliased_constant_references_are_renamed` verifies `AliasConst` does not appear in minified output and no preamble is generated
- [x] All existing constant aliaser tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)