### PR TITLE
fix: skip unresolved constants in external prefix aliasing

### DIFF
--- a/lib/ruby_minify/analysis/constant/collection.rb
+++ b/lib/ruby_minify/analysis/constant/collection.rb
@@ -187,7 +187,7 @@ module RubyMinify
       resolved_cpath = resolve_constant_read_cpath(node)
       is_user_defined = (full_path && @constant_mapping.user_defined_path?(full_path)) ||
                         (resolved_cpath && @constant_mapping.user_defined_path?(resolved_cpath))
-      effective_path = resolved_cpath || full_path
+      effective_path = resolved_cpath
       if effective_path && !is_user_defined
         next if effective_path.size < 2
         next if full_path && @constant_mapping.has_user_defined_prefix?(full_path)

--- a/tests/ruby_minify/pipeline/test_constant_aliaser.rb
+++ b/tests/ruby_minify/pipeline/test_constant_aliaser.rb
@@ -145,6 +145,43 @@ class TestConstantAliaserPipeline < Minitest::Test
     assert_equal '', result.preamble
   end
 
+  def test_unresolved_external_constant_inside_module_not_aliased_in_preamble
+    code = <<~RUBY
+      module RuboCopLike
+        module Cop
+          class AssignmentCheck
+            EQUALS = AST::Node::EQUALS_ASSIGNMENTS
+            EQUALS2 = AST::Node::EQUALS_ASSIGNMENTS
+            EQUALS3 = AST::Node::EQUALS_ASSIGNMENTS
+            def check(node)
+              EQUALS.include?(node.type) || EQUALS2.include?(node.type) || EQUALS3.include?(node.type)
+            end
+          end
+        end
+      end
+    RUBY
+    result = minify_at_level(code, 2, verify_output: false)
+    assert_equal '', result.preamble
+  end
+
+  def test_unresolved_top_level_external_constant_not_aliased_in_preamble
+    code = <<~RUBY
+      class Worker
+        def run
+          SomeGem::Config.load
+          SomeGem::Config.load
+          SomeGem::Config.load
+          SomeGem::Config.load
+          SomeGem::Config.load
+        end
+      end
+    RUBY
+    result = minify_at_level(code, 2, verify_output: false)
+    assert_equal '', result.preamble
+    assert_equal 'class Worker;def run =(SomeGem::Config.load;SomeGem::Config.load;SomeGem::Config.load;SomeGem::Config.load;SomeGem::Config.load);end',
+                 result.code
+  end
+
   def test_aliased_constant_references_are_renamed
     code = <<~RUBY
       module Outer


### PR DESCRIPTION
## Summary

- Fix `collect_external_references` to only use TypeProf-resolved (fully-qualified) paths for external prefix registration, dropping the syntactic fallback (`build_constant_path`)
- Syntactic paths are scope-dependent (e.g., `AST::Node` inside `module RuboCop` resolves to `RuboCop::AST::Node` at runtime, but the syntactic path is just `[:AST, :Node]`), causing incorrect preamble declarations at the top level
- Unresolved constants keep their original references in the code, which work correctly via Ruby's natural constant lookup since module nesting is preserved

## Test plan

- [x] New test `test_unresolved_external_constant_inside_module_not_aliased_in_preamble` — verifies `AST::Node` inside a module scope does not generate preamble
- [x] New test `test_unresolved_top_level_external_constant_not_aliased_in_preamble` — verifies unresolved top-level constants also skip preamble (TypeProf can't guarantee the syntactic path is correct)
- [x] Existing `test_external_prefix_aliased` (`Process::Status`) still passes — resolved paths are unaffected
- [x] All 828 tests pass

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Minifier now avoids emitting alias declarations for unresolved external constants, preventing incorrect preamble entries when constants can't be resolved.

* **Tests**
  * Added tests to ensure unresolved external constants are not aliased in the preamble and that code remains unchanged when such references appear.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->